### PR TITLE
Libraries etc

### DIFF
--- a/src/Cabal2Nix/Name.hs
+++ b/src/Cabal2Nix/Name.hs
@@ -16,10 +16,22 @@ toNixName name    = f name
 -- possibility of name clashes with Haskell libraries. I have included
 -- identity mappings to incicate that I have verified their correctness.
 libNixName :: String -> String
-libNixName "adns"     = "adns"
-libNixName "pcre"     = "pcre"
-libNixName "pq"       = "postgresql"
-libNixName "sqlite3"  = "sqlite"
-libNixName "X11"      = "libX11"
-libNixName "z"        = "zlib"
-libNixName x          = x
+libNixName "adns"      = "adns"
+libNixName "cairo"     = "cairo"
+libNixName "cairo-pdf" = "cairo"
+libNixName "cairo-ps"  = "cairo"
+libNixName "cairo-svg" = "cairo"
+libNixName "crypto"    = "openssl"
+libNixName "gnome-keyring" = "gnome_keyring"
+libNixName "gnome-keyring-1" = "gnome_keyring"
+libNixName "idn"       = "idn"
+libNixName "libidn"    = "idn"
+libNixName "libzip"    = "libzip"
+libNixName "pcre"      = "pcre"
+libNixName "pq"        = "postgresql"
+libNixName "sndfile"   = "libsndfile"
+libNixName "sqlite3"   = "sqlite"
+libNixName "xft"       = "libXft"
+libNixName "X11"       = "libX11"
+libNixName "z"         = "zlib"
+libNixName x           = x


### PR DESCRIPTION
This one is perhaps more controversial. But I think that in the short term, it's an improvement.

I think that later, we want to reflect the condtree structure of a package file in the generated Nix expression.

For now, I've used a Cabal function to resolve all flags to their default values, and assume a more or less reasonable platform and compiler version. Compared to your old code, this catches dependencies more accurately.

For library dependencies, I now also consider the pkgconfig-depends field.

(I think that this is all I'm going to do this weekend.)
