### PR TITLE
Handle case when cabal version is not specified

### DIFF
--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -46,7 +46,7 @@ Executable cabal2nix
   main-is:              Cabal2Nix.hs
   hs-source-dirs:       src
   Build-Depends:        base >= 3 && < 5, regex-posix, pretty, Cabal >= 1.8,
-                        filepath, directory, process, HTTP
+                        filepath, directory, process, HTTP, hackage-db
   Extensions:           PatternGuards, RecordWildCards, CPP
   Ghc-Options:          -Wall
   other-modules:        Cabal2Nix.CorePackages


### PR DESCRIPTION
Works like that:

``` bash
$> cabal2nix cabal://mtl
{ cabal, transformers }:

cabal.mkDerivation (self: {
  pname = "mtl";
  version = "2.1.2";
  sha256 = "1vwb98ci3jnjpndym012amia41h3cjdwpy9330ws881l6dj5fxwc";
  buildDepends = [ transformers ];
  meta = {
    homepage = "http://github.com/ekmett/mtl";
    description = "Monad classes, using functional dependencies";
    license = self.stdenv.lib.licenses.bsd3;
    platforms = self.ghc.meta.platforms;
  };
})
```
