### PR TITLE
Added support for LGPL2

### DIFF
--- a/src/Cabal2Nix/License.hs
+++ b/src/Cabal2Nix/License.hs
@@ -10,6 +10,7 @@ fromCabalLicense (GPL (Just (Version [2] [])))     = Known "self.stdenv.lib.lice
 fromCabalLicense (GPL (Just (Version [3] [])))     = Known "self.stdenv.lib.licenses.gpl3"
 fromCabalLicense (LGPL Nothing)                    = Unknown (Just "LGPL")
 fromCabalLicense (LGPL (Just (Version [2,1] [])))  = Known "self.stdenv.lib.licenses.lgpl21"
+fromCabalLicense (LGPL (Just (Version [2] [])))  = Known "self.stdenv.lib.licenses.lgpl2"
 fromCabalLicense (LGPL (Just (Version [3] [])))    = Known "self.stdenv.lib.licenses.gpl3"
 fromCabalLicense BSD3                              = Known "self.stdenv.lib.licenses.bsd3"
 fromCabalLicense BSD4                              = Known "self.stdenv.lib.licenses.bsd4"


### PR DESCRIPTION
A one line modification so cabal2nix can handle cabal projects that use LGPL2.

This also means that cabal2nix can generate a nix expression for all of the latest packages found at:
http://hackage.haskell.org/packages/archive/00-archive.tar
At least as of a day ago.
