### PR TITLE
idris and llvm-general

### DIFF
--- a/src/Cabal2Nix/PostProcess.hs
+++ b/src/Cabal2Nix/PostProcess.hs
@@ -35,9 +35,7 @@ postProcess deriv@(MkDerivation {..})
   | pname == "highlighting-kate"= highlightingKatePostProcessing deriv
   | pname == "hmatrix"          = deriv { extraLibs = "gsl":"liblapack":"blas":extraLibs }
   | pname == "hspec"            = deriv { doCheck = False }
-  | pname == "idris"            = if version < Version [0,9,9] []
-                                    then deriv { buildTools = "happy":buildTools, extraLibs = "gmp":extraLibs }
-                                    else deriv { buildTools = "happy":buildTools, extraLibs = "gmp":"boehmgc":extraLibs }
+  | pname == "idris"            = deriv { buildTools = "happy":buildTools, extraLibs = "gmp":"boehmgc":extraLibs }
   | pname == "language-c-quote" = deriv { buildTools = "alex":"happy":buildTools }
   | pname == "language-java"    = deriv { buildDepends = "syb":buildDepends }
   | pname == "leksah-server"    = deriv { buildDepends = "process-leksah":buildDepends }


### PR DESCRIPTION
idris 0.9.9 is in master now
And the llvm-general upgrade broke the testphase of these packages.
Also, idris is very specific about the llvm-general version it needs. Jailbreak didn't work (confusion over the split into llvm-general-pure), so I had to bring back the old version and force that to idris.
I don't think any changes in cabal2nix are needed for that though.
