### PR TITLE
Compile snap-server with openssl support

### DIFF
--- a/src/Cabal2Nix/Flags.hs
+++ b/src/Cabal2Nix/Flags.hs
@@ -15,6 +15,7 @@ configureCabalFlags (PackageIdentifier (PackageName name) _)
  | name == "idris"              = [enable "llvm", enable "gmp", enable "ffi"]
  | name == "io-streams"         = [enable "NoInteractiveTests"]
  | name == "reactive-banana-wx" = [disable "buildExamples"]
+ | name == "snap-server"        = [enable "openssl"]
  | name == "xmobar"             = [enable "all_extensions"]
  | name == "xmonad-extras"      = [disable "with_hlist", enable "with_split", enable "with_parsec"]
  | name == "yi"                 = [enable "pango"]


### PR DESCRIPTION
snap-server has cmd args which we can enable or disable https. Hence it is useful to build it with openssl support.
