### PR TITLE
enable GIO support in GTK package

### DIFF
--- a/src/Cabal2Nix/PostProcess.hs
+++ b/src/Cabal2Nix/PostProcess.hs
@@ -2,8 +2,8 @@
 
 module Cabal2Nix.PostProcess ( postProcess ) where
 
-import Distribution.NixOS.Derivation.Cabal
 import Data.List
+import Distribution.NixOS.Derivation.Cabal
 
 postProcess :: Derivation -> Derivation
 postProcess deriv@(MkDerivation {..})
@@ -36,7 +36,7 @@ postProcess deriv@(MkDerivation {..})
   | pname == "glib"             = deriv { extraLibs = "pkgconfig":"libc":extraLibs }
   | pname == "gloss-raster"     = deriv { extraLibs = "llvm":extraLibs }
   | pname == "GLUT"             = deriv { extraLibs = "glut":"libSM":"libICE":"libXmu":"libXi":"mesa":extraLibs }
-  | pname == "gtk"              = deriv { extraLibs = "pkgconfig":"libc":extraLibs, buildDepends = delete "gio" buildDepends }
+  | pname == "gtk"              = deriv { extraLibs = "pkgconfig":"libc":extraLibs }
   | pname == "gtkglext"         = deriv { pkgConfDeps = "pangox_compat":pkgConfDeps }
   | pname == "gtk2hs-buildtools"= deriv { buildDepends = "hashtables":buildDepends }
   | pname == "gtksourceview2"   = deriv { extraLibs = "pkgconfig":"libc":extraLibs }


### PR DESCRIPTION
The flag enable-gio is True by default, so I suppose we should also
build GTK with GIO in nixpkgs. The hackage haddocks are also built with
GIO enabled, so it can be confusing if GIO is disabled in nixpkgs' gtk
version and thus some functions that are documented on hackage are
missing in the nixpkgs version. It took me some time to find out why I cannot use `iconThemeLookupByGIcon` even though that function was documented on hackage. 
