### PR TITLE
Don't wrap raw Yi at all

### DIFF
--- a/src/Cabal2Nix/PostProcess.hs
+++ b/src/Cabal2Nix/PostProcess.hs
@@ -118,7 +118,7 @@ postProcess deriv@(MkDerivation {..})
                                         , configureFlags = "--extra-include-dirs=${freetype}/include/freetype2":configureFlags
                                         }
   | pname == "xmonad"           = deriv { phaseOverrides = xmonadPostInstall }
-  | pname == "yi"               = deriv { runHaddock = True, phaseOverrides = yiPhases, buildTools = "makeWrapper":buildTools }
+  | pname == "yi"               = deriv { runHaddock = True, phaseOverrides = yiFixHaddock }
   | otherwise                   = deriv
 
 cudaConfigurePhase :: String
@@ -209,14 +209,6 @@ xmonadPostInstall = unlines
 
 yiFixHaddock :: String
 yiFixHaddock = "noHaddock = self.stdenv.lib.versionOlder self.ghc.version \"7.8\";"
-
-yiPhases :: String
-yiPhases = unlines
-  [ yiFixHaddock
-  , "postInstall = ''"
-  , "  wrapProgram $out/bin/yi --suffix GHC_PACKAGE_PATH : $out/lib/ghc-${self.ghc.version}/package.conf.d/yi-$version.installedconf:$GHC_PACKAGE_PATH"
-  , "'';"
-  ]
 
 gitAnnexOverrides :: String
 gitAnnexOverrides = unlines


### PR DESCRIPTION
We do the wrapping in hand-written yi-custom and use ghcWithPackages
instead which works like a charm and relieves us from this stupid double-wrapping
