### PR TITLE
Add gsl extraLib dependency to hmatrix-special

### DIFF
--- a/src/Cabal2Nix/PostProcess.hs
+++ b/src/Cabal2Nix/PostProcess.hs
@@ -57,6 +57,7 @@ postProcess deriv@(MkDerivation {..})
   | pname == "hlibgit2"         = deriv { testDepends = "git":testDepends }
   | pname == "HList"            = deriv { buildTools = "diffutils":buildTools }
   | pname == "hmatrix"          = deriv { extraLibs = "liblapack":"blas": filter (/= "lapack") extraLibs }
+  | pname == "hmatrix-special"  = deriv { extraLibs = "gsl":extraLibs }
   | pname == "hoogle"           = deriv { testTarget = "--test-option=--no-net" }
   | pname == "hspec"            = deriv { doCheck = False }
   | pname == "hsyslog"          = deriv { phaseOverrides = hsyslogNoHaddock }


### PR DESCRIPTION
Adds gsl to the list of extraLibs for hmatrix-special.
