### PR TITLE
Recognise "exposed: False" attribute of Cabal library stanza

### DIFF
--- a/src/Cabal2Nix/Generate.hs
+++ b/src/Cabal2Nix/Generate.hs
@@ -17,7 +17,7 @@ cabal2nix cabal = normalize $ postProcess MkDerivation
   { pname          = let Cabal.PackageName x = Cabal.pkgName pkg in x
   , version        = Cabal.pkgVersion pkg
   , src            = error "cabal2nix left the src field undefined"
-  , isLibrary      = isJust (Cabal.library tpkg)
+  , isLibrary      = maybe False Cabal.libExposed (Cabal.library tpkg)
   , isExecutable   = not (null (Cabal.executables tpkg))
   , extraFunctionArgs = []
   , buildDepends   = map unDep deps


### PR DESCRIPTION
Tested by generating expressions for vimus (isLibrary should be false) and xmonad (should be true).
