### PR TITLE
Diagrams-builder enabling of flags for all supported backends.

### DIFF
--- a/src/Cabal2Nix/Flags.hs
+++ b/src/Cabal2Nix/Flags.hs
@@ -7,6 +7,7 @@ configureCabalFlags :: PackageIdentifier -> FlagAssignment
 configureCabalFlags (PackageIdentifier (PackageName name) _)
  | name == "arithmoi"           = [disable "llvm"]
  | name == "accelerate-examples"= [disable "opencl"]
+ | name == "diagrams-builder"   = [enable "cairo", enable "svg", enable "ps", enable "rasterific"]
  | name == "folds"              = [disable "test-hlint"]
  | name == "git-annex"          = [enable "Assistant" , enable "Production"]
  | name == "haskeline"          = [enable "terminfo"]


### PR DESCRIPTION
This is required to create the diagrams-builder package without manually changing its nix expression. 