### PR TITLE
bytestring-arbitrary: Add "llvm" extraLib

### DIFF
--- a/src/Cabal2Nix/PostProcess.hs
+++ b/src/Cabal2Nix/PostProcess.hs
@@ -26,6 +26,7 @@ postProcess' deriv@(MkDerivation {..})
   | pname == "bits-extras"      = deriv { configureFlags = Set.insert "--ghc-option=-lgcc_s" configureFlags
                                         , extraLibs = Set.filter (/= "gcc_s") extraLibs
                                         }
+  | pname == "bytestring-arbitrary" = deriv { extraLibs = Set.insert "llvm" extraLibs }
   | pname == "Cabal"            = deriv { phaseOverrides = "preCheck = \"unset GHC_PACKAGE_PATH; export HOME=$NIX_BUILD_TOP\";" }
   | pname == "cabal-bounds"     = deriv { buildTools = Set.insert "cabal-install" buildTools }
   | pname == "cabal-install" && version >= Version [0,14] []


### PR DESCRIPTION
Warning: I have not yet built or run this code.  Apologies in advance if it's junk.

bytestring-arbitrary from nixpkgs' haskell NG doesn't build for me.  The error makes me think it has something to do with the -fllvm option in its [cabal file](https://github.com/tsuraan/bytestring-arbitrary/blob/master/bytestring-arbitrary.cabal).

Addings pkgs.llvm to the extraLibs in its hackage-packages.nix definition fixed the issue for me.  But that's a generated file.  I can't commit those changes upstream directly.  I'm trying to commit the equivalent changes here instead.