### PR TITLE
Better error reporting in case of IO errors

### DIFF
--- a/src/Cabal2Nix/Package.hs
+++ b/src/Cabal2Nix/Package.hs
@@ -133,7 +133,7 @@ cabalFromFile failHard file =
   -- that do not represent valid characters. To catch that exception, we need to
   -- wrap the whole block in `catchIO`, because of lazy IO. The `case` will force
   -- the reading of the file, so we will always catch the expression here.
-  MaybeT $ handleIO (const $ return Nothing) $ do
+  MaybeT $ handleIO (\err -> Nothing <$ hPutStrLn stderr ("*** parsing cabal file: " ++ show err)) $ do
     content <- readFile file
     case Cabal.parsePackageDescription content of
       Cabal.ParseFailed e | failHard -> do


### PR DESCRIPTION
Failing silently in case of an IO error is really confusing. This patch makes cabal2nix at least print a message. 