### PR TITLE
update post-processing for liquid-fixpoint and liquidhaskell

### DIFF
--- a/src/Cabal2Nix/PostProcess.hs
+++ b/src/Cabal2Nix/PostProcess.hs
@@ -72,7 +72,8 @@ postProcess' deriv@(MkDerivation {..})
   | pname == "leksah-server"    = deriv { buildDepends = Set.insert "process-leksah" buildDepends }
   | pname == "lhs2tex"          = deriv { extraLibs = Set.insert "texLive" extraLibs, phaseOverrides = lhs2texPostInstall }
   | pname == "libffi"           = deriv { extraLibs = Set.delete "ffi" extraLibs }
-  | pname == "liquid-fixpoint"  = deriv { buildTools = Set.insert "ocaml" buildTools }
+  | pname == "liquid-fixpoint"  = deriv { buildTools = Set.insert "ocaml" buildTools, configureFlags = Set.insert "-fbuild-external" configureFlags }
+  | pname == "liquidhaskell"    = deriv { doCheck = False } -- test-suite requires cvc4 or z3
   | pname == "llvm-base"        = deriv { extraLibs = Set.insert "llvm" extraLibs }
   | pname == "llvm-general"     = deriv { doCheck = False }
   | pname == "llvm-general-pure"= deriv { doCheck = False }


### PR DESCRIPTION
liquid-fixpoint needs the `-fbuild-external` flag to force building the
ocaml binary locally instead of using a precompiled binary (not
guaranteed to work in nixos AFAIK)