### PR TITLE
add bootstrap.nix to ease .cabal file generation

### DIFF
--- a/bootstrap.nix
+++ b/bootstrap.nix
@@ -1,0 +1,20 @@
+with (import <nixpkgs> {}).pkgs;
+let pkg = haskellngPackages.callPackage
+            ({ mkDerivation, base, cartel, mtl, process, stdenv }:
+             mkDerivation {
+               pname = "generate-cabal-file";
+               version = "0.1.0.0";
+               src = ./.;
+               isLibrary = false;
+               isExecutable = true;
+               buildDepends = [ base cartel mtl process ];
+               license = stdenv.lib.licenses.bsd3;
+             }) {};
+in
+  pkgs.lib.overrideDerivation pkg.env (drv: {
+    shellHook = ''
+      ${drv.shellHook}
+      make cabal2nix.cabal
+      exit 1
+    '';
+  })


### PR DESCRIPTION
I went ahead and made a possible solution for #155. This is basically auto-generated with `cabal2nix --shell` with a changed `shellHook`.