### PR TITLE
Enable fixed data-hash, uhc-light builds

### DIFF
--- a/src/hackage2nix.hs
+++ b/src/hackage2nix.hs
@@ -1010,7 +1010,6 @@ defaultConfiguration = Configuration
     , "data-dispersal"
     , "data-easy"
     , "data-extra"
-    , "data-hash"
     , "data-ivar"
     , "data-lens-ixset"
     , "datalog"

--- a/src/hackage2nix.hs
+++ b/src/hackage2nix.hs
@@ -3844,7 +3844,6 @@ defaultConfiguration = Configuration
     , "udbus"
     , "udbus-model"
     , "udev"
-    , "uhc-light"
     , "uhttpc"
     , "ui-command"
     , "UISF"


### PR DESCRIPTION
Both builds work now on GHC 7.10.

data-hash was fixed in https://github.com/NixOS/nixpkgs/pull/7693
uhc-light has been fixed upstream