### PR TITLE
add `z3` to the buildTools for liquid-fixpoint and liquidhaskell so we can run the tests

### DIFF
--- a/src/Cabal2Nix/PostProcess.hs
+++ b/src/Cabal2Nix/PostProcess.hs
@@ -71,8 +71,8 @@ postProcess' deriv@(MkDerivation {..})
   | pname == "language-java"    = deriv { buildDepends = Set.insert "syb" buildDepends }
   | pname == "lhs2tex"          = deriv { extraLibs = Set.insert "texLive" extraLibs, phaseOverrides = lhs2texPostInstall }
   | pname == "libffi"           = deriv { extraLibs = Set.delete "ffi" extraLibs }
-  | pname == "liquid-fixpoint"  = deriv { buildTools = Set.insert "ocaml" buildTools, configureFlags = Set.insert "-fbuild-external" configureFlags }
-  | pname == "liquidhaskell"    = deriv { doCheck = False } -- test-suite requires cvc4 or z3
+  | pname == "liquid-fixpoint"  = deriv { buildTools = Set.insert "z3" (Set.insert "ocaml" buildTools), configureFlags = Set.insert "-fbuild-external" configureFlags }
+  | pname == "liquidhaskell"    = deriv { buildTools = Set.insert "z3" buildTools }
   | pname == "llvm-base"        = deriv { extraLibs = Set.insert "llvm" extraLibs }
   | pname == "llvm-general"     = deriv { doCheck = False }
   | pname == "llvm-general-pure"= deriv { doCheck = False }


### PR DESCRIPTION
NB: `z3` takes a while to build (and liquidhaskell has a large testsuite too). Should we mention this somewhere so people can be aware and possibly choose to disable tests locally?