### PR TITLE
hackage2nix: whitelist meep package

### DIFF
--- a/src/hackage2nix.hs
+++ b/src/hackage2nix.hs
@@ -2495,7 +2495,6 @@ defaultConfiguration = Configuration
     , "mecab"
     , "mediawiki"
     , "mediawiki2latex"
-    , "meep"
     , "mega-sdist"
     , "melody"
     , "memory"


### PR DESCRIPTION
http://hydra.cryp.to/build/864879/log/raw - this error was fixed in the last version of `meep` package.

Can we remove it now from the list of broken packages?