### PR TITLE
Write error messages for parse failures to stderr

### DIFF
--- a/src/Cabal2Nix/Package.hs
+++ b/src/Cabal2Nix/Package.hs
@@ -137,7 +137,7 @@ cabalFromFile failHard file =
       Cabal.ParseFailed e | failHard -> do
         let (line, err) = ParseUtils.locatedErrorMsg e
             msg = maybe "" ((++ ": ") . show) line ++ err
-        putStrLn $ "*** error parsing cabal file: " ++ msg
+        hPutStrLn stderr $ "*** error parsing cabal file: " ++ msg
         exitFailure
       Cabal.ParseFailed _  -> return Nothing
       Cabal.ParseOk     _ a -> return (Just a)


### PR DESCRIPTION
Currently, when running `cabal2nix . > foo.nix` against a malformed cabal file, the error message ends up in `foo.nix` and `cabal2nix` appears to fail silently, which is not ideal.