### PR TITLE
Add z3 to the DYLD_LIBRARY_PATH on darwin

### DIFF
--- a/src/Cabal2Nix/PostProcess.hs
+++ b/src/Cabal2Nix/PostProcess.hs
@@ -120,6 +120,7 @@ postProcess' deriv@(MkDerivation {..})
   | pname == "SDL2-ttf"         = deriv { buildDepends = Set.delete "SDL2" buildDepends }
   | pname == "jsaddle"          = deriv { buildDepends = Set.delete "ghcjs-base" buildDepends, testDepends = Set.delete "ghcjs-base" testDepends }
   | pname == "hzk"              = deriv { testDepends = Set.delete "zookeeper_mt" testDepends, buildTools = Set.insert "zookeeper_mt" buildTools }
+  | pname == "z3"               = deriv { preBuild = "if stdenv.isDarwin then \"export DYLD_LIBRARY_PATH=${z3}/lib\" else null" }
   | pname == "zip-archive"      = deriv { testDepends = Set.delete "zip" testDepends, buildTools = Set.insert "zip" buildTools }
   | otherwise                   = deriv
 


### PR DESCRIPTION
It fails to build with

```
Executing: dist/build/Z3/Base/C_hsc_make  >dist/build/Z3/Base/C.hs
dyld: Library not loaded: libz3.dylib
  Referenced from: dist/build/Z3/Base/C_hsc_make
  Reason: image not found
running dist/build/Z3/Base/C_hsc_make failed (exit code -5)
command was: dist/build/Z3/Base/C_hsc_make  >dist/build/Z3/Base/C.hs
```

otherwise.