### PR TITLE
Fix build for haskell package 'gf'

### DIFF
--- a/src/hackage2nix.hs
+++ b/src/hackage2nix.hs
@@ -1404,7 +1404,6 @@ defaultConfiguration = Configuration
     , "GeomPredicates-SSE"
     , "getemx"
     , "getflag"
-    , "gf"
     , "ggtsTC"
     , "ghc-dup"
     , "ghc-events-analyze"


### PR DESCRIPTION
The building of the `gf` Haskell package is a bit special. Not only it builds the `gf` compiler and related Haskell libraries, but also a standard library for the GF (Grammatical Framework) programming language, which are themselves compiled with the `gf` compiler. 

This change allows for the full `gf` package to be built. 