### PR TITLE
lmdb: remove from broken packages

### DIFF
--- a/src/hackage2nix.hs
+++ b/src/hackage2nix.hs
@@ -2428,7 +2428,6 @@ defaultConfiguration = Configuration
     , "llvm-ffi"
     , "llvm-general-quote"
     , "llvm-ht"
-    , "lmdb"
     , "local-search"
     , "loch"
     , "lock-file"


### PR DESCRIPTION
adding the lmdb c library to nixpkgs seems to fix breakage:

nixos/nixpkgs@9d85874aeb6f17bc1b13c1a248f319e1908e1210

This also unbreaks vache and vcache-trie which are currently
marked broken in nixpkgs