### PR TITLE
Don't store hashes taken from the command line.

### DIFF
--- a/src/cabal2nix.hs
+++ b/src/cabal2nix.hs
@@ -78,7 +78,7 @@ main :: IO ()
 main = bracket (return ()) (\() -> hFlush stdout >> hFlush stderr) $ \() -> do
   cfg <- execParser pinfo
 
-  pkg <- getPackage (optHackageDb cfg) $ Source (optUrl cfg) (fromMaybe "" (optRevision cfg)) (optSha256 cfg)
+  pkg <- getPackage (optHackageDb cfg) $ Source (optUrl cfg) (fromMaybe "" (optRevision cfg)) (maybe UnknownHash Guess (optSha256 cfg))
 
   let flags = readFlagList (optFlags cfg)
 

--- a/src/hackage2nix.hs
+++ b/src/hackage2nix.hs
@@ -41,6 +41,7 @@ import Data.Monoid
 import Data.Set ( Set )
 import qualified Data.Set as Set
 import Distribution.Compiler
+import Distribution.Nixpkgs.Fetch
 import Distribution.Nixpkgs.Haskell
 import Distribution.Nixpkgs.PackageMap
 import Distribution.Nixpkgs.Util.PrettyPrinting hiding ( attr, (<>) )
@@ -156,7 +157,7 @@ generatePackageSet config hackage nixpkgs = do
               putStrLn ""
   pkgs <- flip parMapM (Map.toAscList db) $ \(name, vs) -> do
     defs <- forM (Set.toAscList vs) $ \pkgversion -> do
-      srcSpec <- liftIO $ sourceFromHackage Nothing (name ++ "-" ++ display pkgversion)
+      srcSpec <- liftIO $ sourceFromHackage UnknownHash (name ++ "-" ++ display pkgversion)
       let Just cabalFileHash = lookup "x-cabal-file-hash" (customFieldsPD (packageDescription descr))
 
           -- TODO: Include list of broken dependencies in the generated output.


### PR DESCRIPTION
This fixes #140.

Before:

```
+ rm -rf /home/jchee/.cache/cabal2nix

+ .cabal-sandbox/bin/cabal2nix --sha256 foo cabal2nix.cabal
+ grep sha256
  sha256 = "foo";

+ cat /home/jchee/.cache/cabal2nix/cabal2nix-20150716.sha256 /dev/fd/63
++ echo
foo

+ .cabal-sandbox/bin/cabal2nix cabal://cabal2nix
mirror://hackage/cabal2nix-1.73.tar.gz expands to http://hackage.haskell.org/package/cabal2nix-1.73.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 27048  100 27048    0     0  80933      0 --:--:-- --:--:-- --:--:-- 80933
path is ‘/nix/store/wvwx9jxca3fbvrd95kknzsp3hy2jma4d-cabal2nix-1.73.tar.gz’
{ mkDerivation, base, Cabal, containers, deepseq, directory
, doctest, filepath, hackage-db, mtl, pretty, process, regex-posix
, stdenv, transformers
}:
mkDerivation {
  pname = "cabal2nix";
  version = "1.73";
  revision = "5";
  sha256 = "1nskcr8k5a8wm9q5is0b1kww574q2nq45f16agya8z44hgk97xiv";
  editedCabalFile = "54866b8081ddfc72761c1f38cc96df6782682058cd09b465300562910f57e2ea";
  isLibrary = false;
  isExecutable = true;
  buildDepends = [
    base Cabal containers deepseq directory filepath hackage-db mtl
    pretty process regex-posix transformers
  ];
  testDepends = [ base doctest ];
  homepage = "http://github.com/NixOS/cabal2nix";
  description = "Convert Cabal files into Nix build instructions";
  license = stdenv.lib.licenses.bsd3;
}

+ cat /home/jchee/.cache/cabal2nix/cabal2nix-1.73.sha256 /dev/fd/63
++ echo
1nskcr8k5a8wm9q5is0b1kww574q2nq45f16agya8z44hgk97xiv
```





After:

```
+ rm -rf /home/jchee/.cache/cabal2nix

+ .cabal-sandbox/bin/cabal2nix --sha256 foo cabal2nix.cabal
+ grep sha256
  sha256 = "foo";

+ ls /home/jchee/.cache/cabal2nix/cabal2nix-20150716.sha256
ls: cannot access /home/jchee/.cache/cabal2nix/cabal2nix-20150716.sha256: No such file or directory

+ .cabal-sandbox/bin/cabal2nix cabal://cabal2nix
{ mkDerivation, base, Cabal, containers, deepseq, directory
, doctest, filepath, hackage-db, mtl, pretty, process, regex-posix
, stdenv, transformers
}:
mkDerivation {
  pname = "cabal2nix";
  version = "1.73";
  revision = "5";
  sha256 = "1nskcr8k5a8wm9q5is0b1kww574q2nq45f16agya8z44hgk97xiv";
  editedCabalFile = "54866b8081ddfc72761c1f38cc96df6782682058cd09b465300562910f57e2ea";
  isLibrary = false;
  isExecutable = true;
  buildDepends = [
    base Cabal containers deepseq directory filepath hackage-db mtl
    pretty process regex-posix transformers
  ];
  testDepends = [ base doctest ];
  homepage = "http://github.com/NixOS/cabal2nix";
  description = "Convert Cabal files into Nix build instructions";
  license = stdenv.lib.licenses.bsd3;
}

+ cat /home/jchee/.cache/cabal2nix/cabal2nix-1.73.sha256 /dev/fd/63
++ echo
1nskcr8k5a8wm9q5is0b1kww574q2nq45f16agya8z44hgk97xiv
```
