### PR TITLE
Try keeping an older version of tar around.

### DIFF
--- a/src/hackage2nix.hs
+++ b/src/hackage2nix.hs
@@ -316,6 +316,7 @@ defaultConfiguration = Configuration
     , "seqid < 0.2"                     -- newer versions depend on transformers 0.4.x which we cannot provide in GHC 7.8.x
     , "seqid-streams < 0.2"             -- newer versions depend on transformers 0.4.x which we cannot provide in GHC 7.8.x
     , "split < 0.2"                     -- newer versions don't work with GHC 6.12.3
+    , "tar < 0.4.2"                     -- newer versions don't work with the bytestring in GHC prior to 7.6.x
     , "vector < 0.10.10"                -- newer versions don't work with GHC 6.12.3
     , "zlib < 0.6"                      -- newer versions break cabal-install
     ]


### PR DESCRIPTION
7.0-7.4 don't have bytestring recent enough to build with the new version of tar, so hydra.cryp.to is showing failures for some packages with those versions. I think this is the necessary incantation to keep the most recent version < 0.4.2 around---at least it mirrors what aeson does.  Then with strategic overrides, I believe, we can get the older versions building again.