### PR TITLE
Fix package lookup for shadowed system packages

### DIFF
--- a/src/Cabal2Nix/Normalize.hs
+++ b/src/Cabal2Nix/Normalize.hs
@@ -26,6 +26,7 @@ normalize drv = drv
 normalizeBuildInfo :: PackageName -> BuildInfo -> BuildInfo
 normalizeBuildInfo (PackageName pname) bi = bi
   & haskell . contains (Identifier pname) .~ False
+  & tool . contains (Identifier pname) .~ False
   & tool %~ normalizeNixBuildTools . Set.filter (\(Identifier n) -> n `notElem` coreBuildTools)
 
   {-

--- a/src/hackage2nix.hs
+++ b/src/hackage2nix.hs
@@ -206,9 +206,8 @@ generatePackageSet config hackage nixpkgs = do
 
           formatOverride :: Attribute -> Maybe Path -> Doc
           formatOverride n Nothing   = space <> text n <> text " = null;"       -- missing attribute
-          formatOverride n (Just [])                                            -- Haskell package:
-            | n == name              = formatOverride n Nothing                 --     refers to a missing system library
-            | otherwise              = mempty                                   --     found by callPackage
+          formatOverride n (Just []) = (text " inherit" <+> text n) <> semi
+          formatOverride _ (Just ["self"]) = mempty -- callPackage finds this package already
           formatOverride n (Just p)  = (text " inherit" <+> parens (text (intercalate "." p)) <+> text n) <> semi
 
           overrides :: Doc
@@ -238,7 +237,7 @@ generatePackageSet config hackage nixpkgs = do
 
 resolveHackageThenNixpkgsAttribute :: Nixpkgs -> Hackage -> Attribute -> Maybe Path
 resolveHackageThenNixpkgsAttribute nixpkgs hackage name
-  | Just _ <- Map.lookup name hackage                   = Just []
+  | Just _ <- Map.lookup name hackage                   = Just ["self"]
   | p@(Just _) <- resolveNixpkgsAttribute nixpkgs name  = p
   | otherwise                                           = Nothing
 


### PR DESCRIPTION
System packages which have the same package name as haskell packages should be brought
into scope by using `inherit systemPackageName;`. Previously, `hackage2nix` would
generate `systemPackageName = null` or nothing at all instead.

The change introduces a slight problem for executables that depend on themselves as a
tool (c2hs' testsuite for example depends on the c2hs tool). To fix this, such a
dependency is now removed in the normalization step of cabal2nix.