### PR TITLE
twilio: disable test suite

### DIFF
--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -88,6 +88,7 @@ hooks =
   , ("target", set (testDepends . system . contains (pkg "z3")) True)
   , ("terminfo", set (libraryDepends . system . contains (pkg "ncurses")) True)
   , ("thyme", set (libraryDepends . tool . contains (bind "self.cpphs")) True) -- required on Darwin
+  , ("twilio", set doCheck False)         -- attempts to access the network
   , ("tz", set phaseOverrides "preConfigure = \"export TZDIR=${pkgs.tzdata}/share/zoneinfo\";")
   , ("websockets", set doCheck False)   -- https://github.com/jaspervdj/websockets/issues/104
   , ("wxcore", set (libraryDepends . pkgconfig . contains (pkg "wxGTK")) True)


### PR DESCRIPTION
It requires some environment variables to be set in order to run against
a Twilio account. Not something we want to do I don't think.