### PR TITLE
hlibgit2: all newer versions should get pkg.git

### DIFF
--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -57,7 +57,7 @@ hooks =
   , ("hakyll", set (testDepends . tool . contains (pkg "utillinux")) True) -- test suite depends on "rev"
   , ("hfsevents", over (metaSection . platforms) (Set.filter (\(Platform _ os) -> os == OtherOS "darwin")))
   , ("HFuse", set phaseOverrides hfusePreConfigure)
-  , ("hlibgit2 == 0.18.0.14", set (testDepends . tool . contains (pkg "git")) True)
+  , ("hlibgit2 >= 0.18.0.14", set (testDepends . tool . contains (pkg "git")) True)
   , ("hmatrix", set phaseOverrides "preConfigure = \"sed -i hmatrix.cabal -e 's@/usr/@/dont/hardcode/paths/@'\";")
   , ("holy-project", set doCheck False)         -- attempts to access the network
   , ("hslua", over (libraryDepends . each) (replace (pkg "lua") (pkg "lua5_1")))


### PR DESCRIPTION
This package has been broken since haskellPackages.git was introduced a
couple of weeks ago *and* the newer version became the default, because
only this specific rev was getting the pkg.git dependency.  Simply
loosen the dependency to fix.