### PR TITLE
Allow building with ghc-8.0.1

### DIFF
--- a/distribution-nixpkgs/distribution-nixpkgs.cabal
+++ b/distribution-nixpkgs/distribution-nixpkgs.cabal
@@ -29,7 +29,7 @@ library
     , bytestring
     , Cabal >= 1.22.2
     , containers
-    , deepseq-generics
+    , deepseq >= 1.4
     , directory
     , filepath
     , hackage-db
@@ -82,7 +82,7 @@ test-suite spec
     , bytestring
     , Cabal >= 1.22.2
     , containers
-    , deepseq-generics
+    , deepseq >= 1.4
     , directory
     , filepath
     , hackage-db
@@ -98,7 +98,6 @@ test-suite spec
     , unordered-containers
     , utf8-string
     , yaml
-    , deepseq
     , distribution-nixpkgs
     , doctest
     , hspec

--- a/distribution-nixpkgs/package.yaml
+++ b/distribution-nixpkgs/package.yaml
@@ -15,7 +15,7 @@ dependencies:
   - bytestring
   - Cabal >= 1.22.2
   - containers
-  - deepseq-generics
+  - deepseq >= 1.4
   - directory
   - filepath
   - hackage-db
@@ -61,7 +61,7 @@ tests:
     source-dirs:
       - test
     dependencies:
-      - deepseq
+      - deepseq >= 1.4
       - distribution-nixpkgs
       - doctest
       - hspec

--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/Fetch.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/Fetch.hs
@@ -11,7 +11,7 @@ module Distribution.Nixpkgs.Fetch
   ) where
 
 import Control.Applicative
-import Control.DeepSeq.Generics
+import Control.DeepSeq
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Maybe
@@ -32,12 +32,12 @@ data Source = Source
   , sourceHash      :: Hash         -- ^ The expected hash of the source, if available.
   } deriving (Show, Eq, Ord, Generic)
 
-instance NFData Source where rnf = genericRnf
+instance NFData Source
 
 data Hash = Certain String | Guess String | UnknownHash
   deriving (Show, Eq, Ord, Generic)
 
-instance NFData Hash where rnf = genericRnf
+instance NFData Hash
 
 isUnknown :: Hash -> Bool
 isUnknown UnknownHash = True
@@ -57,7 +57,7 @@ data DerivationSource = DerivationSource
   }
   deriving (Show, Eq, Ord, Generic)
 
-instance NFData DerivationSource where rnf = genericRnf
+instance NFData DerivationSource
 
 instance FromJSON DerivationSource where
   parseJSON (Object o) = DerivationSource (error "undefined DerivationSource.kind")

--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/BuildInfo.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/BuildInfo.hs
@@ -9,7 +9,7 @@ module Distribution.Nixpkgs.Haskell.BuildInfo
   )
   where
 
-import Control.DeepSeq.Generics
+import Control.DeepSeq
 import Data.Set ( Set )
 import Data.Set.Lens
 import GHC.Generics ( Generic )
@@ -35,7 +35,7 @@ instance Monoid BuildInfo where
   mempty = BuildInfo mempty mempty mempty mempty
   BuildInfo w1 x1 y1 z1 `mappend` BuildInfo w2 x2 y2 z2 = BuildInfo (w1 `mappend` w2) (x1 `mappend` x2) (y1 `mappend` y2) (z1 `mappend` z2)
 
-instance NFData BuildInfo where rnf = genericRnf
+instance NFData BuildInfo
 
 pPrintBuildInfo :: String -> BuildInfo -> Doc
 pPrintBuildInfo prefix bi = vcat

--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/Derivation.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/Derivation.hs
@@ -12,7 +12,7 @@ module Distribution.Nixpkgs.Haskell.Derivation
   )
   where
 
-import Control.DeepSeq.Generics
+import Control.DeepSeq
 import Data.List
 import Data.Set ( Set )
 import qualified Data.Set as Set
@@ -92,7 +92,7 @@ makeLensesFor [("_libraryDepends", "dependencies"), ("_executableDepends", "depe
 instance Package Derivation where
   packageId = view pkgid
 
-instance NFData Derivation where rnf = genericRnf
+instance NFData Derivation
 
 instance Pretty Derivation where
   pPrint drv@(MkDerivation {..}) = funargs (map text ("mkDerivation" : toAscList inputs)) $$ vcat

--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/FromCabal/Configuration.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/FromCabal/Configuration.hs
@@ -7,7 +7,7 @@
 
 module Distribution.Nixpkgs.Haskell.FromCabal.Configuration ( Configuration(..), readConfiguration, assertConsistency ) where
 
-import Control.DeepSeq.Generics
+import Control.DeepSeq
 import Control.Lens
 import Control.Monad
 import Data.Map as Map
@@ -49,7 +49,7 @@ data Configuration = Configuration
   }
   deriving (Show, Generic)
 
-instance NFData Configuration where rnf = genericRnf
+instance NFData Configuration
 
 instance FromJSON Configuration where
   parseJSON (Object o) = Configuration

--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
@@ -6,7 +6,7 @@
 
 module Distribution.Nixpkgs.Haskell.OrphanInstances ( ) where
 
-import Control.DeepSeq.Generics
+import Control.DeepSeq
 import Data.Maybe
 import Data.String
 import qualified Data.Text as T
@@ -29,45 +29,45 @@ deriving instance Generic ConfVar
 deriving instance Generic Flag
 deriving instance Generic GenericPackageDescription
 #else
-instance NFData SetupBuildInfo where rnf = genericRnf
+instance NFData SetupBuildInfo
 #endif
 
-instance (NFData v, NFData c, NFData a) => NFData (CondTree v c a) where rnf = genericRnf
-instance NFData Arch where rnf = genericRnf
-instance NFData Benchmark where rnf = genericRnf
-instance NFData BenchmarkInterface where rnf = genericRnf
-instance NFData BenchmarkType where rnf = genericRnf
-instance NFData BuildInfo where rnf = genericRnf
-instance NFData BuildType where rnf = genericRnf
-instance NFData CompilerFlavor where rnf = genericRnf
-instance NFData ConfVar where rnf = genericRnf
-instance NFData Dependency where rnf = genericRnf
-instance NFData Executable where rnf = genericRnf
-instance NFData Extension where rnf = genericRnf
-instance NFData Flag where rnf = genericRnf
-instance NFData FlagName where rnf = genericRnf
-instance NFData GenericPackageDescription where rnf = genericRnf
-instance NFData KnownExtension where rnf = genericRnf
-instance NFData Language where rnf = genericRnf
-instance NFData Library where rnf = genericRnf
-instance NFData License where rnf = genericRnf
-instance NFData ModuleName where rnf = genericRnf
-instance NFData ModuleReexport where rnf = genericRnf
-instance NFData ModuleRenaming where rnf = genericRnf
-instance NFData OS where rnf = genericRnf
-instance NFData PackageDescription where rnf = genericRnf
-instance NFData RepoKind where rnf = genericRnf
-instance NFData RepoType where rnf = genericRnf
-instance NFData SourceRepo where rnf = genericRnf
-instance NFData TestSuite where rnf = genericRnf
-instance NFData TestSuiteInterface where rnf = genericRnf
-instance NFData TestType where rnf = genericRnf
-instance NFData VersionRange where rnf = genericRnf
-instance NFData a => NFData (Condition a) where rnf = genericRnf
-instance NFData Platform where rnf = genericRnf
-instance NFData CompilerInfo where rnf = genericRnf
-instance NFData CompilerId where rnf = genericRnf
-instance NFData AbiTag where rnf = genericRnf
+instance (NFData v, NFData c, NFData a) => NFData (CondTree v c a)
+instance NFData Arch
+instance NFData Benchmark
+instance NFData BenchmarkInterface
+instance NFData BenchmarkType
+instance NFData BuildInfo
+instance NFData BuildType
+instance NFData CompilerFlavor
+instance NFData ConfVar
+instance NFData Dependency
+instance NFData Executable
+instance NFData Extension
+instance NFData Flag
+instance NFData FlagName
+instance NFData GenericPackageDescription
+instance NFData KnownExtension
+instance NFData Language
+instance NFData Library
+instance NFData License
+instance NFData ModuleName
+instance NFData ModuleReexport
+instance NFData ModuleRenaming
+instance NFData OS
+instance NFData PackageDescription
+instance NFData RepoKind
+instance NFData RepoType
+instance NFData SourceRepo
+instance NFData TestSuite
+instance NFData TestSuiteInterface
+instance NFData TestType
+instance NFData VersionRange
+instance NFData a => NFData (Condition a)
+instance NFData Platform
+instance NFData CompilerInfo
+instance NFData CompilerId
+instance NFData AbiTag
 
 instance IsString PackageName where
   fromString = text2isString "PackageName"

--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/License.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/License.hs
@@ -7,7 +7,7 @@
 
 module Distribution.Nixpkgs.License ( License(..) ) where
 
-import Control.DeepSeq.Generics
+import Control.DeepSeq
 import Data.Maybe
 import GHC.Generics ( Generic )
 import Internal.PrettyPrinting
@@ -44,4 +44,4 @@ instance Pretty License where
   pPrint (Known x)   = text x
   pPrint (Unknown x) = string (fromMaybe "unknown" x)
 
-instance NFData License where rnf = genericRnf
+instance NFData License

--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/Meta.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/Meta.hs
@@ -14,7 +14,7 @@ module Distribution.Nixpkgs.Meta
   , allKnownPlatforms
   ) where
 
-import Control.DeepSeq.Generics
+import Control.DeepSeq
 import Control.Lens
 import Data.Set ( Set )
 import qualified Data.Set as Set
@@ -57,7 +57,7 @@ data Meta = Meta
 
 makeLenses ''Meta
 
-instance NFData Meta where rnf = genericRnf
+instance NFData Meta
 
 instance Pretty Meta where
   pPrint Meta {..} = vcat

--- a/hackage2nix/hackage2nix.cabal
+++ b/hackage2nix/hackage2nix.cabal
@@ -30,7 +30,7 @@ executable hackage2nix
     , bytestring
     , Cabal >= 1.22.2
     , containers
-    , deepseq-generics
+    , deepseq >= 1.4
     , directory
     , distribution-nixpkgs
     , filepath

--- a/hackage2nix/package.yaml
+++ b/hackage2nix/package.yaml
@@ -15,7 +15,7 @@ dependencies:
   - bytestring
   - Cabal >= 1.22.2
   - containers
-  - deepseq-generics
+  - deepseq >= 1.4
   - directory
   - distribution-nixpkgs
   - filepath

--- a/hackage2nix/src/Stackage.hs
+++ b/hackage2nix/src/Stackage.hs
@@ -4,7 +4,7 @@
 
 module Stackage where
 
-import Control.DeepSeq.Generics
+import Control.DeepSeq
 import Control.Exception ( assert )
 import Control.Monad
 import Control.Monad.Par.Combinator
@@ -50,9 +50,9 @@ data Snapshot = Snapshot
   deriving (Show, Generic)
 
 deriving instance Generic SnapshotType
-instance NFData Spec where
-instance NFData Snapshot where
-instance NFData SnapshotType where
+instance NFData Spec
+instance NFData Snapshot
+instance NFData SnapshotType
 
 instance Pretty SnapshotType where
   pPrint STNightly = text "stackage-nightly"


### PR DESCRIPTION
As of deepseq-1.4.0, the ability to derive generics has been folded into the main library.  Furthermore, deepseq-1.4.2.0 is included with ghc-8.0.1 (and 1.4.1.1 was bundled with ghc-7.10.1).

Before this change, attempts to compile with ghc-8.0.1 would throw errors like:
```
  src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs:32:10: error:
      Not in scope: type constructor or class ‘NFData’
```
Changing to just use the automatic deriviation seemed like the easiest way to resolve the issue.  I *believe* this will just work on 7.10.x and with the exception of  a couple of terms, might simply work all the way back to the "beginning of time"...or at least when NFData first appeared.