### PR TITLE
Supply Qt 5 to Qtah.

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -96,6 +96,8 @@ hooks =
   , ("pandoc", set jailbreak False) -- jailbreak-cabal break the build
   , ("pandoc >= 1.16.0.2", set doCheck False) -- https://github.com/jgm/pandoc/issues/2709 and https://github.com/fpco/stackage/issues/1332
   , ("pandoc-citeproc", set doCheck False) -- https://github.com/jgm/pandoc-citeproc/issues/172
+  , ("qtah-cpp-qt5", set (libraryDepends . system . contains (bind "pkgs.qt5.qtbase")) True)
+  , ("qtah-qt5", set (libraryDepends . tool . contains (bind "pkgs.qt5.qtbase")) True)
   , ("readline", over (libraryDepends . system) (Set.union (pkgs ["readline", "ncurses"])))
   , ("rocksdb-haskell", set (metaSection . platforms) (Set.singleton (Platform X86_64 Linux)))
   , ("sdr", over (metaSection . platforms) (Set.filter (\(Platform arch _) -> arch == X86_64))) -- https://github.com/adamwalker/sdr/issues/2


### PR DESCRIPTION
qtah-cpp-qt5 and qtah-qt5 need Qt supplied as a build input.  Both invoke qmake (provided by `qt5.qtbase`) during the configure phase, and qtah-cpp-qt5 also links to Qt libraries.

I hit dependency issues trying to build cabal2nix locally to test this PR, but I'm trying to create this change in Nixpkgs: https://github.com/khumba/nixpkgs/commit/206292273500a51fbf19cc93f17c292df8d1ad34, and Qtah builds successfully at that commit.