### PR TITLE
Make sure that pango gets the appropriate pango dependency

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -98,6 +98,7 @@ hooks =
   , ("mysql", set (libraryDepends . system . contains (pkg "mysql")) True)
   , ("network-attoparsec", set doCheck False) -- test suite requires network access
   , ("numeric-qq", set doCheck False) -- test suite doesn't finish even after 1+ days
+  , ("pango", set (libraryDepends . system . contains (bind "pkgs.gnome2.pango")) True)
   , ("pandoc", set jailbreak False) -- jailbreak-cabal break the build
   , ("pandoc >= 1.16.0.2", set doCheck False) -- https://github.com/jgm/pandoc/issues/2709 and https://github.com/fpco/stackage/issues/1332
   , ("pandoc-citeproc", set doCheck False) -- https://github.com/jgm/pandoc-citeproc/issues/172


### PR DESCRIPTION
If you do `git blame` on `pkgs/development/haskell-modules/hackage-packages.nix` in `nixpkgs/master`, you'll see this one modification that sticks out like a sore thumb:

```
bccd75094 (Kirill Boltaev        2016-09-12 00:24:51 +0300 124889)      }) {inherit (pkgs.gnome2) pango;};
```

If you look at that line (the end of the `pango` expression) in `peti/haskell-updates`, it has:

```
   }) {inherit (pkgs.gnome) pango;};
```

This fails to evaluate:

```
error: attribute ‘gnome’ missing, at /home/mdorman/src/nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix:126236:19
(use ‘--show-trace’ to show detailed location information)
nix-env failed with error code 1.
```

So it seems clear to me that we need to have `cabal2nix` create the appropriate dependency automatically.  I _think_ this change does that.
