### PR TITLE
Enabled cabal2nix to hash the Cabal file when --hackage-db is specified.

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/Hackage.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Hackage.hs
@@ -1,4 +1,4 @@
-module Distribution.Nixpkgs.Haskell.Hackage ( readHashedHackage, module Distribution.Hackage.DB ) where
+module Distribution.Nixpkgs.Haskell.Hackage ( readHashedHackage, readHashedHackage', module Distribution.Hackage.DB ) where
 
 import Data.ByteString.Lazy ( ByteString )
 import Data.Digest.Pure.SHA ( sha256, showDigest )
@@ -13,7 +13,10 @@ import qualified Distribution.Hackage.DB.Unparsed as Unparsed
 -- original tarball.
 
 readHashedHackage :: IO Hackage
-readHashedHackage = fmap parseUnparsedHackage Unparsed.readHackage
+readHashedHackage = hackagePath >>= readHashedHackage'
+
+readHashedHackage' :: FilePath -> IO Hackage
+readHashedHackage' = fmap parseUnparsedHackage . Unparsed.readHackage'
   where
     parseUnparsedHackage :: Unparsed.Hackage -> Hackage
     parseUnparsedHackage = mapWithKey (mapWithKey . parsePackage)

--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -48,7 +48,7 @@ fetchOrFromDB optHackageDB src
 
 fromDB :: Maybe String -> String -> IO Cabal.GenericPackageDescription
 fromDB optHackageDB pkg = do
-  pkgDesc <- (lookupVersion <=< DB.lookup name) <$> maybe DB.readHashedHackage DB.readHackage' optHackageDB
+  pkgDesc <- (lookupVersion <=< DB.lookup name) <$> maybe DB.readHashedHackage DB.readHashedHackage' optHackageDB
   case pkgDesc of
     Just r -> return r
     Nothing -> hPutStrLn stderr "*** no such package in the cabal database (did you run cabal update?). " >> exitFailure


### PR DESCRIPTION
@peti This fixes the issue I mentioned, #255.