### PR TITLE
Add post-processing for gi-pangocairo

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -63,6 +63,7 @@ hooks =
   , ("gi-gtk", giGtkPhaseOverrides)                         -- https://github.com/haskell-gi/haskell-gi/issues/36
   , ("gi-javascriptcore", giJavascriptCorePhaseOverrides)   -- https://github.com/haskell-gi/haskell-gi/issues/36
   , ("gi-pango", giCairoPhaseOverrides)                     -- https://github.com/haskell-gi/haskell-gi/issues/36
+  , ("gi-pangocairo", giPangoCairoPhaseOverrides)           -- https://github.com/haskell-gi/haskell-gi/issues/36
   , ("gi-webkit2", giWebkit2PhaseOverrides)                 -- https://github.com/haskell-gi/haskell-gi/issues/36
   , ("gi-webkit2webextension", giWebkit2PhaseOverrides)     -- https://github.com/haskell-gi/haskell-gi/issues/36
   , ("gio", set (libraryDepends . pkgconfig . contains "system-glib = pkgs.glib") True)
@@ -310,6 +311,21 @@ giCairoPhaseOverrides = over phaseOverrides (++'\n':txt)
     txt = unlines [ "preCompileBuildDriver = ''"
                   , "  PKG_CONFIG_PATH+=\":${cairo}/lib/pkgconfig\""
                   , "  setupCompileFlags+=\" $(pkg-config --libs cairo-gobject)\""
+                  , "'';"
+                  ]
+
+giPangoCairoPhaseOverrides :: Derivation -> Derivation
+giPangoCairoPhaseOverrides = set phaseOverrides txt
+                           . over (libraryDepends . pkgconfig) addPkgs
+  where
+    addPkgs = Set.union (Set.fromList [ "system-pango = pkgs.pango"
+                                      , "system-cairo = pkgs.cairo" ])
+            . Set.insert (pkg "gobjectIntrospection")
+    gir = [ "system-pango.dev" ]
+    txt = unlines [ "preConfigure = ''" ++ exportGirSearchPath gir ++ "'';"
+                  , "preCompileBuildDriver = ''"
+                  , "  PKG_CONFIG_PATH+=\":${system-pango.dev}/lib/pkgconfig:${system-cairo.dev}/lib/pkgconfig\""
+                  , "  setupCompileFlags+=\" $(pkg-config --libs pangocairo cairo-gobject)\""
                   , "'';"
                   ]
 


### PR DESCRIPTION
Add overrides to let gi-pangocairo build. Relevant to NixOS/nixpkgs#21993.

I have tested this with:
```
./dist/build/cabal2nix/cabal2nix --shell cabal://gi-pangocairo > gi-pangocairo.nix
nix-build gi-pangocairo.nix
```

In the cabal2nix case, the `system-pango = pkgs.pango` and `system-cairo = pkgs.cairo` variables need to be manually added to the `callPackage ` arguments. But I am assuming that with hackage2nix, it will just work, as it does for the `gio` package (`system-gio = pkgs.gio`).