### PR TITLE
improve license error

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -1,7 +1,9 @@
 module Distribution.Nixpkgs.Haskell.FromCabal.License ( fromCabalLicense ) where
 
 import Distribution.Nixpkgs.License
-import Distribution.License ( License(..) )
+import Distribution.License ( License(..), knownLicenses )
+import Distribution.Text (display)
+import Data.List (intercalate)
 import Data.Version
 
 -- TODO: Programatically strip trailing zeros from license version numbers.
@@ -31,4 +33,5 @@ fromCabalLicense (Apache Nothing)                       = Known "stdenv.lib.lice
 fromCabalLicense (Apache (Just (Version [2,0] [])))     = Known "stdenv.lib.licenses.asl20"
 fromCabalLicense ISC                                    = Known "stdenv.lib.licenses.isc"
 fromCabalLicense OtherLicense                           = Unknown Nothing
-fromCabalLicense l                                      = error $ "Distribution.Nixpkgs.Haskell.FromCabal.License.fromCabalLicense: unknown license " ++ show l
+fromCabalLicense l                                      = error $ "Distribution.Nixpkgs.Haskell.FromCabal.License.fromCabalLicense: unknown license"
+                                                            ++ show l ++"\nChoose one of: " ++ intercalate ", " (map display knownLicenses)


### PR DESCRIPTION
```
cabal2nix: Distribution.Nixpkgs.Haskell.FromCabal.License.fromCabalLicense: unknown licenseUnknownLicense "GPL3"
Choose one of: GPL, GPL-2, GPL-3, LGPL, LGPL-2.1, LGPL-3, AGPL, AGPL-3, BSD2, BSD3, MIT, ISC, MPL-2.0, Apache, Apache-2.0, PublicDomain, AllRightsReserved, OtherLicense
CallStack (from HasCallStack):
  error, called at src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs:36:59 in cabal2nix-2.1.1-Ha1HfKuK3utC69EpNllx2j:Distribution.Nixpkgs.Haskell.FromCabal.License
```