### PR TITLE
xmonad: allow man page installation without "enableSeparateDocOutput"

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -226,9 +226,8 @@ xmonadPostInstall :: String
 xmonadPostInstall = unlines
   [ "postInstall = ''"
   , "  shopt -s globstar"
-  , "  mkdir -p $doc/share/man/man1"
-  , "  mv \"$data/\"**\"/man/\"*[0-9] $doc/share/man/man1/"
-  , "  rm \"$data/\"**\"/man/\"*"
+  , "  mkdir -p $out/share/man/man1"
+  , "  cp ./man/xmonad.1 $out/share/man/man1/"
   , "'';"
   ]
 


### PR DESCRIPTION
e9e96691 required `enableSeparateDataOutput` and `enableSeparateDocOutput` to both be true to work. Furthermore, it relied on the strange fact that xmonad puts the man page in data-dir (https://hackage.haskell.org/package/xmonad-0.13/xmonad.cabal). Given that this is not used from the source code, this is likely a bug in XMonad and I will follow up on this.

We can instead pick the man page directly from the source directory `.`.

Using `$out` will still work with split outputs. [multiple-outputs.sh:145](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/multiple-outputs.sh#L145) will move the man page from `$out` to `${outputMan}`