### PR TITLE
Agda: fix postInstall to account for multiple outputs.

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -235,7 +235,7 @@ xmonadPostInstall = unlines
 agdaPostInstall :: String
 agdaPostInstall = unlines
   [ "postInstall = ''"
-  , "  $out/bin/agda -c --no-main $(find $out/share -name Primitive.agda)"
+  , "  $out/bin/agda -c --no-main $(find $data/share -name Primitive.agda)"
   , "  $out/bin/agda-mode compile"
   , "'';"
   ]
@@ -243,7 +243,7 @@ agdaPostInstall = unlines
 agda25PostInstall :: String
 agda25PostInstall = unlines
   [ "postInstall = ''"
-  , "  files=(\"$out/share/\"*\"-ghc-\"*\"/Agda-\"*\"/lib/prim/Agda/\"{Primitive.agda,Builtin\"/\"*.agda})"
+  , "  files=(\"$data/share/ghc-\"*\"/\"*\"-ghc-\"*\"/Agda-\"*\"/lib/prim/Agda/\"{Primitive.agda,Builtin\"/\"*.agda})"
   -- Separate loops to avoid internal error
   , "  for f in \"''${files[@]}\" ; do"
   , "    $out/bin/agda $f"


### PR DESCRIPTION
Relevant nixpkgs issues - https://github.com/NixOS/nixpkgs/issues/28466 & https://github.com/NixOS/nixpkgs/issues/28643

Agda itself builds but can't build other packages:

- https://hydra.nixos.org/build/59622963
- https://hydra.nixos.org/build/59621250

I only tested Agda >= 2.5 case by building `nixpkgs.agdaPrelude` and `nixpkgs.AgdaStdlib` against a recent nixpkgs master and Agda expression adjusted as per output of cabal2nix with this change. I'm assuming the same issue exists for Agda < 2.5.