### PR TITLE
fix #307: hmatrix-special

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -75,7 +75,7 @@ hooks =
   , ("hfsevents", hfseventsOverrides)
   , ("HFuse", set phaseOverrides hfusePreConfigure)
   , ("hlibgit2 >= 0.18.0.14", set (testDepends . tool . contains (pkg "git")) True)
-  , ("hmatrix", set phaseOverrides "preConfigure = \"sed -i hmatrix.cabal -e 's@/usr/@/dont/hardcode/paths/@'\";")
+  , ("hmatrix", set phaseOverrides "preConfigure = \"sed -i hmatrix.cabal -e '/\\/usr\\//D'\";")
   , ("holy-project", set doCheck False)         -- attempts to access the network
   , ("hoogle", set testTarget "--test-option=--no-net")
   , ("hsignal < 0.2.7.4", set phaseOverrides "prePatch = \"rm -v Setup.lhs\";") -- https://github.com/amcphail/hsignal/issues/1


### PR DESCRIPTION
The prior code did a sed substitution of the dangerous /usr/ path in
hmatrix.cabal with a safer /dont/hardcode/path one.  That's fine for
compilation of hmatrix, but hmatrix-special (which depends on hmatrix)
then fails to compile because an impure (outside /nix/store) link is
detected.

Here's an illustration of the problem:

```
$ nix-build -A haskellPackages.hmatrix-special
...
impure path `/dont/hardcode/paths/lib/openblas/lib' used in link
collect2: error: ld returned 1 exit status
```

So this commit deletes the problematic reference in hmatrix.cabal,
rather than substitute it.  hmatrix.cabal is still well-formed and
hmatrix compiles.  But now hmatrix-special can compile too.