### PR TITLE
Mapping for libssh2

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
@@ -130,6 +130,7 @@ libNixName "sane-backends"                      = return "saneBackends"
 libNixName "sass"                               = return "libsass"
 libNixName "sctp"                               = return "lksctp-tools" -- This is linux-specific, we should create a common attribute if we ever add sctp support for other systems.
 libNixName "sdl2"                               = return "SDL2"
+libNixName "ssh2"                               = return "libssh2"
 libNixName "sndfile"                            = return "libsndfile"
 libNixName "sodium"                             = return "libsodium"
 libNixName "sqlite3"                            = return "sqlite"


### PR DESCRIPTION
Set the mapping for the cabal "ssh2" package to the Nix "libssh2" package.