### PR TITLE
Add -fexeconly flag to idris package

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs
@@ -42,7 +42,7 @@ configureCabalFlags (PackageIdentifier name version)
                                 = [enable "externalLibsass"]
  | name == "hmatrix"            = [enable "openblas"]
  | name == "hslua"              = [enable "system-lua"]
- | name == "idris"              = [enable "gmp", enable "ffi", enable "curses"]
+ | name == "idris"              = [enable "gmp", enable "ffi", enable "curses", ("execonly", version `withinRange` (orLaterVersion (mkVersion [1,1,1]))) ]
  | name == "io-streams"         = [enable "NoInteractiveTests"]
  | name == "liquid-fixpoint"    = [enable "build-external"]
  | name == "pandoc"             = [enable "https", disable "trypandoc"]


### PR DESCRIPTION
If you don't pass this flag then the package fails to build due to linker
errors.

In nixpkgs this flag is currently passed manually. The libraries are
built later on. 

https://github.com/NixOS/nixpkgs/blob/1c431f4664d219368710c2db1d1b81e6e556978f/pkgs/development/haskell-modules/configuration-common.nix#L737