### PR TITLE
Added hackage snapshot time as an argument to cabal2nix.

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -79,15 +79,15 @@ options = Options
           <*> option (readP parse) (long "compiler" <> help "compiler to use when evaluating the Cabal file" <> value buildCompilerId <> showDefaultWith display)
           <*> option (readP parsePlatform) (long "system" <> help "target system to use when evaluating the Cabal file" <> value buildPlatform <> showDefaultWith display)
           <*> optional (strOption $ long "subpath" <> metavar "PATH" <> help "Path to Cabal file's directory relative to the URI (default is root directory)")
-          <*> optional (option utcTimeReader (long "hackage-snapshot" <> help "hackage snapshot time, example '09.08.2012 10:54 AM'"))
+          <*> optional (option utcTimeReader (long "hackage-snapshot" <> help "hackage snapshot time, ISO format"))
           <*> strArgument (metavar "URI")
 
--- | A parser for the date. Minutes seem to be a good fit if the change is on Hackage is maybe once or twice a month.
--- Example: parseTime defaultTimeLocale "%d.%m.%Y %l:%M %p" "09.08.2012 10:54 AM" :: Maybe UTCTime
+-- | A parser for the date. Hackage updates happen maybe once or twice a month.
+-- Example: parseTime defaultTimeLocale "%FT%T%QZ" "2017-11-20T12:18:35Z" :: Maybe UTCTime
 utcTimeReader :: ReadM UTCTime
 utcTimeReader = eitherReader $ \arg ->
-    case parseTimeM True defaultTimeLocale "%d.%m.%Y %l:%M %p" arg of
-        Nothing      -> Left ("Cannot parse date: " ++ arg)
+    case parseTimeM True defaultTimeLocale "%FT%T%QZ" arg of
+        Nothing      -> Left $ "Cannot parse date, ISO format used ('2017-11-20T12:18:35Z'): " ++ arg
         Just utcTime -> Right utcTime
 
 readP :: P.ReadP a a -> ReadM a

--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -12,6 +12,7 @@ import Data.Maybe ( fromMaybe )
 import Data.Monoid ( (<>) )
 import qualified Data.Set as Set
 import Data.String
+import Data.Time
 import qualified Distribution.Compat.ReadP as P
 import Distribution.Compiler
 import Distribution.Nixpkgs.Fetch
@@ -52,6 +53,7 @@ data Options = Options
   , optCompiler :: CompilerId
   , optSystem :: Platform
   , optSubpath :: Maybe FilePath
+  , optHackageSnapshot :: Maybe UTCTime
   , optUrl :: String
   }
   deriving (Show)
@@ -77,7 +79,16 @@ options = Options
           <*> option (readP parse) (long "compiler" <> help "compiler to use when evaluating the Cabal file" <> value buildCompilerId <> showDefaultWith display)
           <*> option (readP parsePlatform) (long "system" <> help "target system to use when evaluating the Cabal file" <> value buildPlatform <> showDefaultWith display)
           <*> optional (strOption $ long "subpath" <> metavar "PATH" <> help "Path to Cabal file's directory relative to the URI (default is root directory)")
+          <*> optional (option utcTimeReader (long "hackage-snapshot" <> help "hackage snapshot time, example '09.08.2012 10:54 AM'"))
           <*> strArgument (metavar "URI")
+
+-- | A parser for the date. Minutes seem to be a good fit if the change is on Hackage is maybe once or twice a month.
+-- Example: parseTime defaultTimeLocale "%d.%m.%Y %l:%M %p" "09.08.2012 10:54 AM" :: Maybe UTCTime
+utcTimeReader :: ReadM UTCTime
+utcTimeReader = eitherReader $ \arg ->
+    case parseTimeM True defaultTimeLocale "%d.%m.%Y %l:%M %p" arg of
+        Nothing      -> Left ("Cannot parse date: " ++ arg)
+        Just utcTime -> Right utcTime
 
 readP :: P.ReadP a a -> ReadM a
 readP p = eitherReader $ \s -> case [ r' | (r',"") <- P.readP_to_S p s ] of
@@ -129,7 +140,7 @@ cabal2nix' :: [String] -> IO (Either Doc Derivation)
 cabal2nix' args = do
   Options {..} <- handleParseResult $ execParserPure defaultPrefs pinfo args
 
-  pkg <- getPackage optHpack optHackageDb $ Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
+  pkg <- getPackage optHpack optHackageDb optHackageSnapshot $ Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
 
   let
       withHpackOverrides :: Derivation -> Derivation


### PR DESCRIPTION
Added hackage snapshot time as an argument.
Local tests:
```
./dist/build/cabal2nix/cabal2nix --hackage-snapshot="09.08.2017 10:54 AM" cabal://mtl

{ mkDerivation, base, stdenv, transformers }:
mkDerivation {
  pname = "mtl";
  version = "2.2.1";
  sha256 = "cae59d79f3a16f8e9f3c9adc1010c7c6cdddc73e8a97ff4305f6439d855c8dc5";
  revision = "1";
  editedCabalFile = "0fsa965g9h23mlfjzghmmhcb9dmaq8zpm374gby6iwgdx47q0njb";
  libraryHaskellDepends = [ base transformers ];
  homepage = "http://github.com/ekmett/mtl";
  description = "Monad classes, using functional dependencies";
  license = stdenv.lib.licenses.bsd3;
}
```
```
./dist/build/cabal2nix/cabal2nix --hackage-snapshot="09.08.2011 10:54 AM" cabal://mtl

{ mkDerivation, base, stdenv, transformers }:
mkDerivation {
  pname = "mtl";
  version = "2.0.1.0";
  sha256 = "1w6jpzyl08mringnd6gxwcl3y9q506r240vm1sv0aacml1hy8szk";
  libraryHaskellDepends = [ base transformers ];
  description = "Monad classes, using functional dependencies";
  license = stdenv.lib.licenses.bsd3;
}
```
```
./dist/build/cabal2nix/cabal2nix --hackage-snapshot="09.08.2010 10:54 AM" cabal://mtl

{ mkDerivation, base, stdenv }:
mkDerivation {
  pname = "mtl";
  version = "1.1.0.2";
  sha256 = "0dldllhq86xks8sw3r5h4a1n1969xsajzi75646g8dz3n7ral9d2";
  libraryHaskellDepends = [ base ];
  description = "Monad transformer library";
  license = stdenv.lib.licenses.bsd3;
}
```
```
./dist/build/cabal2nix/cabal2nix --hackage-snapshot="09.08.2007 10:54 AM" cabal://mtl

{ mkDerivation, base, stdenv }:
mkDerivation {
  pname = "mtl";
  version = "1.0";
  sha256 = "1r1c7zfbc0jxc28rnbfz2ymbhq6lbnh434a25ga259jci2pybm1k";
  libraryHaskellDepends = [ base ];
  description = "Monad transformer library";
  license = stdenv.lib.licenses.bsd3;
}
```