### PR TITLE
Optimization: allow HackageDB reuse

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -1,5 +1,5 @@
 module Distribution.Nixpkgs.Haskell.PackageSourceSpec
-  ( Package(..), getPackage, sourceFromHackage
+  ( Package(..), getPackage, getPackage', loadHackageDB, sourceFromHackage
   ) where
 
 import qualified Control.Exception as Exception
@@ -43,20 +43,26 @@ getPackage :: Bool
            -> Source
            -> IO Package
 getPackage optHpack optHackageDB optHackageSnapshot source = do
-  (derivSource, ranHpack, pkgDesc) <- fetchOrFromDB optHpack optHackageDB optHackageSnapshot source
+  hackageDB <- loadHackageDB optHackageDB optHackageSnapshot
+  getPackage' optHpack hackageDB source
+
+getPackage' :: Bool
+            -- ^ Whether hpack should regenerate the cabal file.
+            -> DB.HackageDB
+            -> Source
+            -> IO Package
+getPackage' optHpack hackageDB source = do
+  (derivSource, ranHpack, pkgDesc) <- fetchOrFromDB optHpack hackageDB source
   (\s -> Package s ranHpack pkgDesc) <$> maybe (sourceFromHackage (sourceHash source) (showPackageIdentifier pkgDesc) $ sourceCabalDir source) return derivSource
 
 fetchOrFromDB :: Bool
               -- ^ Whether hpack should regenerate the cabal file
-              -> Maybe FilePath
-              -- ^ The path to the Hackage database.
-              -> Maybe UTCTime
-              -- ^ If we have hackage-snapshot time.
+              -> DB.HackageDB
               -> Source
               -> IO (Maybe DerivationSource, Bool, Cabal.GenericPackageDescription)
-fetchOrFromDB optHpack optHackageDB optHackageSnapshot src
+fetchOrFromDB optHpack hackageDB src
   | "cabal://" `isPrefixOf` sourceUrl src = do
-      (msrc, pkgDesc) <- fromDB optHackageDB optHackageSnapshot . drop (length "cabal://") $ sourceUrl src
+      (msrc, pkgDesc) <- fromDB hackageDB . drop (length "cabal://") $ sourceUrl src
       return (msrc, False, pkgDesc)
   | otherwise                             = do
     r <- fetch (\dir -> cabalFromPath optHpack (dir </> sourceCabalDir src)) src
@@ -65,14 +71,20 @@ fetchOrFromDB optHpack optHackageDB optHackageSnapshot src
       Just (derivSource, (externalSource, ranHpack, pkgDesc)) -> do
         return (derivSource <$ guard externalSource, ranHpack, pkgDesc)
 
-fromDB :: Maybe FilePath
-       -> Maybe UTCTime
+loadHackageDB :: Maybe FilePath
+              -- ^ The path to the Hackage database.
+              -> Maybe UTCTime
+              -- ^ If we have hackage-snapshot time.
+              -> IO DB.HackageDB
+loadHackageDB optHackageDB optHackageSnapshot = do
+  dbPath <- maybe DB.hackageTarball return optHackageDB
+  DB.readTarball optHackageSnapshot dbPath
+
+fromDB :: DB.HackageDB
        -> String
        -> IO (Maybe DerivationSource, Cabal.GenericPackageDescription)
-fromDB optHackageDB optHackageSnapshot pkg = do
-  dbPath <- maybe DB.hackageTarball return optHackageDB
-  db <- DB.readTarball optHackageSnapshot dbPath
-  vd <- maybe unknownPackageError return (DB.lookup name db >>= lookupVersion)
+fromDB hackageDB pkg = do
+  vd <- maybe unknownPackageError return (DB.lookup name hackageDB >>= lookupVersion)
   let ds = case DB.tarballSha256 vd of
              Nothing -> Nothing
              Just hash -> Just (DerivationSource "url" url "" hash)


### PR DESCRIPTION
As noted in #313, HackageDB deserialization is rather expensive. This
change allows Haskell projects to deserialize a HackageDB once, and
then make multiple calls to cabal2nix with that DB.

An experimental result with stack2nix shows over a 6x speed
improvement with pandoc and its dependency closure.