### PR TITLE
Make HackageDB lazy to avoid unnecessary parsing

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -151,7 +151,7 @@ cabal2nixWithDB db args = do
   when (isJust optHackageDb) $ hPutStrLn stderr "WARN: HackageDB provided directly; ignoring --hackage-db"
   when (isJust optHackageSnapshot) $ hPutStrLn stderr "WARN: HackageDB provided directly; ignoring --hackage-snapshot"
 
-  pkg <- getPackage' optHpack db $ Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
+  pkg <- getPackage' optHpack (return db) $ Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
   processPackage opts pkg
 
 processPackage :: Options -> Package -> IO (Either Doc Derivation)


### PR DESCRIPTION
I don't like this solution too much, but it does the job. 

Fixes #319 