### PR TITLE
Use identify function over pkgs set for nixpkgs resolving

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -161,7 +161,7 @@ processPackage Options{..} pkg = do
       withHpackOverrides = if pkgRanHpack pkg then hpackOverrides else id
       deriv :: Derivation
       deriv = withHpackOverrides $ fromGenericPackageDescription (const True)
-                                            (\i -> Just (binding # (i, path # [i])))
+                                            (\i -> Just (binding # (i, path # ["pkgs", i])))
                                             optSystem
                                             (unknownCompilerInfo optCompiler NoAbiTag)
                                             (readFlagList optFlags)


### PR DESCRIPTION
Currently cabal2nix for package `zlib` generates `zlib = null` binding, I think `zlib = pkgs.zlib` makes more sense for a default.