### PR TITLE
fltk-config build tool from fltk, for fltkhs

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
@@ -184,6 +184,7 @@ buildToolNixName "nix-build"                    = return "nix"
 buildToolNixName "nix-env"                      = return "nix"
 buildToolNixName "nix-instantiate"              = return "nix"
 buildToolNixName "nix-store"                    = return "nix"
+buildToolNixName "fltk-config"                  = return "fltk"
 buildToolNixName x                              = return (fromString x)
 
 -- | Helper function to extract the package name from a String that may or may


### PR DESCRIPTION
i tested this with my branch of `fltkhs` (which declares system dependencies in the cabal file), and the default `cabal2nix` works correctly. this fixes `haskellPackages.fltkhs` (currently marked broken). 

this pull request, along with https://github.com/deech/fltkhs/pull/71 , fixes https://github.com/deech/fltkhs/issues/16
