### PR TITLE
Fix build for hpack-0.22.0.

### DIFF
--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -104,7 +104,7 @@ library
     , filepath
     , hackage-db >2
     , hopenssl >=2
-    , hpack == 0.21.*
+    , hpack >= 0.21 && < 0.23
     , language-nix
     , lens
     , optparse-applicative

--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -104,7 +104,7 @@ library
     , filepath
     , hackage-db >2
     , hopenssl >=2
-    , hpack >= 0.21 && < 0.23
+    , hpack == 0.22.*
     , language-nix
     , lens
     , optparse-applicative

--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Distribution.Nixpkgs.Haskell.PackageSourceSpec
   ( Package(..), getPackage, getPackage', loadHackageDB, sourceFromHackage
   ) where
@@ -192,18 +191,10 @@ handleIO = Exception.handle
 
 hpackDirectory :: FilePath -> MaybeT IO (Bool, Cabal.GenericPackageDescription)
 hpackDirectory dir = do
-#if MIN_VERSION_hpack(0,22,0)
   mPackage <- liftIO $ Hpack.readPackageConfig "" $ dir </> "package.yaml"
-#else
-  mPackage <- liftIO $ Hpack.readPackageConfig $ dir </> "package.yaml"
-#endif
   case mPackage of
     Left err -> liftIO $ hPutStrLn stderr ("*** hpack error: " ++ show err ++ ". Exiting.") >> exitFailure
-#if MIN_VERSION_hpack(0,22,0)
     Right (pkg', _) -> do
-#else
-    Right (_, pkg') -> do
-#endif
       let hpackOutput = Hpack.renderPackage Hpack.defaultRenderSettings 2 [] [] pkg'
           hash = printSHA256 $ digestString (digestByName "sha256") hpackOutput
       case parseGenericPackageDescription hpackOutput of

--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Distribution.Nixpkgs.Haskell.PackageSourceSpec
   ( Package(..), getPackage, getPackage', loadHackageDB, sourceFromHackage
   ) where
@@ -191,10 +192,18 @@ handleIO = Exception.handle
 
 hpackDirectory :: FilePath -> MaybeT IO (Bool, Cabal.GenericPackageDescription)
 hpackDirectory dir = do
+#if MIN_VERSION_hpack(0,22,0)
+  mPackage <- liftIO $ Hpack.readPackageConfig "" $ dir </> "package.yaml"
+#else
   mPackage <- liftIO $ Hpack.readPackageConfig $ dir </> "package.yaml"
+#endif
   case mPackage of
     Left err -> liftIO $ hPutStrLn stderr ("*** hpack error: " ++ show err ++ ". Exiting.") >> exitFailure
+#if MIN_VERSION_hpack(0,22,0)
+    Right (pkg', _) -> do
+#else
     Right (_, pkg') -> do
+#endif
       let hpackOutput = Hpack.renderPackage Hpack.defaultRenderSettings 2 [] [] pkg'
           hash = printSHA256 $ digestString (digestByName "sha256") hpackOutput
       case parseGenericPackageDescription hpackOutput of


### PR DESCRIPTION
This should probably wait for a reply from the hpack author for clarification of the extra filepath argument, but I think it can be ignored. This commit works for hpack-0.21 and hpack-0.22.

Can remove the macros if you'd rather just drop support for <0.22.