### PR TITLE
Cabal 2 / GHC 8.4 compatibility

### DIFF
--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -119,6 +119,7 @@ library
     , text
     , time
     , transformers
+    , utf8-string
     , yaml
   exposed-modules:
       Cabal2nix

--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -189,5 +189,5 @@ test-suite regression-test
                       , pretty
                       , tasty
                       , tasty-golden
-  ghc-options:          -Wall -with-rtsopts=-K1K
+  ghc-options:          -Wall
   default-language:     Haskell2010

--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -22,7 +22,7 @@ import Distribution.Nixpkgs.Haskell
 import Distribution.Nixpkgs.Haskell.FromCabal
 import Distribution.Nixpkgs.Haskell.FromCabal.Normalize ( normalizeCabalFlags )
 import Distribution.Nixpkgs.Haskell.FromCabal.Flags
-import qualified Distribution.Nixpkgs.Haskell.FromCabal.PostProcess as PP (pkg)
+import qualified Distribution.Nixpkgs.Haskell.FromCabal.PostProcess as PP
 import qualified Distribution.Nixpkgs.Haskell.Hackage as DB
 import Distribution.Nixpkgs.Haskell.PackageSourceSpec
 import Distribution.Nixpkgs.Meta

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -33,6 +34,17 @@ import Distribution.Types.PkgconfigDependency as Cabal
 import Distribution.Types.UnqualComponentName as Cabal
 import Distribution.Version
 import Language.Nix
+
+#if MIN_VERSION_base(4,11,0)
+import Data.Char
+import qualified Data.Map as Map
+import Distribution.License (License(..))
+import qualified Distribution.License as DL
+import qualified Distribution.Parsec.Class as DPC
+import qualified Distribution.Pretty as Pretty
+import qualified Distribution.SPDX as SPDX
+import qualified Distribution.SPDX.LicenseReference as SPDX
+#endif
 
 type HaskellResolver = Dependency -> Bool
 type NixpkgsResolver = Identifier -> Maybe Binding
@@ -73,8 +85,69 @@ finalizeGenericPackageDescription haskellResolver arch compiler flags constraint
                 Right (d,_) -> (d,m)
     Right (d,_)  -> (d,[])
 
+---
+--- Note: this section is only needed for Cabal 2.1, since 2.2 has the license{To,From}SPDX functions.
+--        Although their 2.2 native version have problems: we had to add the second clause to licenseFromSPDX.
+---
+#if MIN_VERSION_base(4,11,0)
+licenseToSPDX :: DL.License -> SPDX.License
+licenseToSPDX l = case l of
+    GPL v | v == version [2]      -> spdx SPDX.GPL_2_0
+    GPL v | v == version [3]      -> spdx SPDX.GPL_3_0
+    LGPL v | v == version [2,1]   -> spdx SPDX.LGPL_2_1
+    LGPL v | v == version [3]     -> spdx SPDX.LGPL_3_0
+    AGPL v | v == version [3]     -> spdx SPDX.AGPL_3_0
+    BSD2                          -> spdx SPDX.BSD_2_Clause
+    BSD3                          -> spdx SPDX.BSD_3_Clause
+    BSD4                          -> spdx SPDX.BSD_4_Clause
+    MIT                           -> spdx SPDX.MIT
+    ISC                           -> spdx SPDX.ISC
+    MPL v | v == mkVersion [2,0]  -> spdx SPDX.MPL_2_0
+    Apache v | v == version [2,0] -> spdx SPDX.Apache_2_0
+    AllRightsReserved             -> SPDX.NONE
+    UnspecifiedLicense            -> SPDX.NONE
+    OtherLicense                  -> ref (SPDX.mkLicenseRef' Nothing "OtherLicense")
+    PublicDomain                  -> ref (SPDX.mkLicenseRef' Nothing "PublicDomain")
+    UnknownLicense str            -> ref (SPDX.mkLicenseRef' Nothing str)
+    _                             -> ref (SPDX.mkLicenseRef' Nothing $ Pretty.prettyShow l)
+  where
+    version = Just . mkVersion
+    spdx    = SPDX.License . SPDX.simpleLicenseExpression
+    ref  r  = SPDX.License $ SPDX.ELicense (SPDX.ELicenseRef r) Nothing
+
+licenseFromSPDX :: SPDX.License -> DL.License
+licenseFromSPDX SPDX.NONE = AllRightsReserved
+licenseFromSPDX (SPDX.License (SPDX.ELicense (SPDX.ELicenseRef lref) Nothing)) =
+  let name = SPDX.licenseRef lref
+      mangle c
+        | isAlphaNum c = Just c
+        | otherwise = Nothing
+      mungle name = fromMaybe (UnknownLicense (mapMaybe mangle name)) (DPC.simpleParsec name)
+  in case name of
+       "LGPL"         -> LGPL Nothing
+       "GPL"          -> GPL Nothing
+       "OtherLicense" -> OtherLicense
+       "PublicDomain" -> PublicDomain
+       _     -> UnknownLicense $ name
+licenseFromSPDX l =
+    fromMaybe (mungle $ Pretty.prettyShow l) $ Map.lookup l m
+  where
+    m :: Map.Map SPDX.License DL.License
+    m = Map.fromList $ filter (isSimple . fst ) $
+        map (\x -> (licenseToSPDX x, x)) DL.knownLicenses
+
+    isSimple (SPDX.License (SPDX.ELicense (SPDX.ELicenseId _) Nothing)) = True
+    isSimple _ = False
+
+    mungle name = fromMaybe (UnknownLicense (mapMaybe mangle name)) (DPC.simpleParsec name)
+
+    mangle c
+        | isAlphaNum c = Just c
+        | otherwise = Nothing
+#endif
+
 fromPackageDescription :: HaskellResolver -> NixpkgsResolver -> [Dependency] -> FlagAssignment -> PackageDescription -> Derivation
-fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags PackageDescription {..} = normalize $ postProcess $ nullDerivation
+fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags desc@PackageDescription {..} = normalize $ postProcess $ nullDerivation
     & isLibrary .~ isJust library
     & pkgid .~ package
     & revision .~ xrev
@@ -115,7 +188,11 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
     xrev = maybe 0 read (lookup "x-revision" customFieldsPD)
 
     nixLicense :: Nix.License
+#if MIN_VERSION_base(4,11,0)
+    nixLicense = fromCabalLicense (licenseFromSPDX $ license desc)
+#else
     nixLicense = fromCabalLicense license
+#endif
 
     resolveInHackage :: Identifier -> Binding
     resolveInHackage i | (i^.ident) `elem` [ unPackageName n | (Dependency n _) <- missingDeps ] = bindNull i

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Distribution.Nixpkgs.Haskell.FromCabal.Flags ( configureCabalFlags ) where
@@ -8,8 +9,16 @@ import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.Version
 
+-- Cabal 2.1 compat: https://github.com/haskell/cabal/commit/6cb6a5165f19fd315bb5dc627cb8531d260d85f9#diff-67a944b99f4af1b1f86dd094973fea18L149
 configureCabalFlags :: PackageIdentifier -> FlagAssignment
-configureCabalFlags (PackageIdentifier name version)
+#if !MIN_VERSION_base(4,11,0)
+configureCabalFlags = configureCabalFlags'
+#else
+configureCabalFlags = mkFlagAssignment . configureCabalFlags'
+#endif
+
+configureCabalFlags' :: PackageIdentifier -> [(FlagName, Bool)]
+configureCabalFlags' (PackageIdentifier name version)
  | name == "accelerate-examples"= [disable "opencl"]
  | name == "arithmoi"           = [disable "llvm"]
  | name == "cabal-plan"         = [enable "exe"]

--- a/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
+++ b/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Distribution.Nixpkgs.Haskell.OrphanInstances ( ) where
@@ -23,6 +24,8 @@ import Distribution.Types.Mixin
 import Distribution.Version
 import Language.Haskell.Extension
 
+-- This is needed for GHC 8.4+, due to new Cabal
+#if !MIN_VERSION_base(4,11,0)
 instance NFData SetupBuildInfo
 instance (NFData v, NFData c, NFData a) => NFData (CondTree v c a)
 instance (NFData v, NFData c, NFData a) => NFData (CondBranch v c a)
@@ -62,6 +65,8 @@ instance NFData TestSuiteInterface
 instance NFData TestType
 instance NFData a => NFData (Condition a)
 instance NFData Platform
+#endif
+
 instance NFData CompilerInfo
 instance NFData CompilerId
 instance NFData AbiTag

--- a/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
+++ b/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
@@ -65,10 +65,11 @@ instance NFData TestSuiteInterface
 instance NFData TestType
 instance NFData a => NFData (Condition a)
 instance NFData Platform
+
+instance NFData CompilerId
 #endif
 
 instance NFData CompilerInfo
-instance NFData CompilerId
 instance NFData AbiTag
 
 instance IsString Version where

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP   #-}
 module Main ( main ) where
 
 import Distribution.Nixpkgs.Haskell.FromCabal
@@ -35,7 +36,11 @@ regressionTest cabalFile = do
                         (\i -> Just (binding # (i, path # [i])))
                         (Platform X86_64 Linux)
                         (unknownCompilerInfo (CompilerId GHC (mkVersion [8,2])) NoAbiTag)
+#if MIN_VERSION_base(4,11,0)
+                        mempty
+#else
                         []
+#endif
                         []
                         gpd
                       & src .~ DerivationSource


### PR DESCRIPTION
@peti, this compiles with GHC 8.4-rc1, however:

1. Should work, but not tested with <8.4, and
2. `8 out of 350 tests failed (2.37s)` -- ~~some of this because of Cabal 2 SPDX/nonSPDX license type mapping I had to manually backport from Cabal 2.2 to Cabal 2.1 (the one in GHC 8.4) -- not sure I got that one right..~~ fixed the license parsing:

```
running tests
Running 1 test suites...
Test suite regression-test: RUNNING...
regression-tests
  test/golden-test-cases/validity-containers.nix:                 OK
  test/golden-test-cases/vector-mmap.nix:                         OK
  test/golden-test-cases/vivid-supercollider.nix:                 OK
  test/golden-test-cases/vty.nix:                                 OK (0.02s)
  test/golden-test-cases/wai-cors.nix:                            OK
  test/golden-test-cases/wai-middleware-auth.nix:                 OK
  test/golden-test-cases/wai-middleware-caching-redis.nix:        OK
  test/golden-test-cases/wai-middleware-prometheus.nix:           OK
  test/golden-test-cases/warp.nix:                                OK
  test/golden-test-cases/weigh.nix:                               FAIL
    --- test/golden-test-cases/weigh.nix.golden 1970-01-01 00:00:01.000000000 +0000
    +++ test/golden-test-cases/weigh.nix        2018-03-01 09:06:21.083129803 +0000
    @@ -1,6 +1,5 @@
    -{ mkDerivation, base, bytestring-trie, containers, deepseq
    -, fetchurl, mtl, process, random, split, template-haskell
    -, temporary, unordered-containers
    +{ mkDerivation, base, deepseq, fetchurl, mtl, process, split
    +, template-haskell, temporary
     }:
     mkDerivation {
       pname = "weigh";
    @@ -12,9 +11,7 @@
       libraryHaskellDepends = [
         base deepseq mtl process split template-haskell temporary
       ];
    -  testHaskellDepends = [
    -    base bytestring-trie containers deepseq random unordered-containers
    -  ];
    +  testHaskellDepends = [ base deepseq ];
       homepage = "https://github.com/fpco/weigh#readme";
       description = "Measure allocations of a Haskell functions/values";
       license = stdenv.lib.licenses.bsd3;
  test/golden-test-cases/xml-hamlet.nix:                          OK
  test/golden-test-cases/xmonad-contrib.nix:                      OK (0.02s)
  test/golden-test-cases/yahoo-finance-api.nix:                   OK
  test/golden-test-cases/yesod-form-bootstrap4.nix:               OK
  test/golden-test-cases/yesod-gitrepo.nix:                       OK
  test/golden-test-cases/yesod-recaptcha2.nix:                    OK
  test/golden-test-cases/zlib.nix:                                OK
  test/golden-test-cases/system-argv0.nix:                        OK
  test/golden-test-cases/system-fileio.nix:                       OK
  test/golden-test-cases/system-filepath.nix:                     OK
  test/golden-test-cases/tagged.nix:                              OK
  test/golden-test-cases/taggy.nix:                               OK
  test/golden-test-cases/tagstream-conduit.nix:                   OK
  test/golden-test-cases/tasty-hedgehog.nix:                      OK
  test/golden-test-cases/tasty-rerun.nix:                         OK
  test/golden-test-cases/tce-conf.nix:                            OK
  test/golden-test-cases/terminal-progress-bar.nix:               OK
  test/golden-test-cases/test-fixture.nix:                        OK
  test/golden-test-cases/texmath.nix:                             FAIL
    --- test/golden-test-cases/texmath.nix.golden       1970-01-01 00:00:01.000000000 +0000
    +++ test/golden-test-cases/texmath.nix      2018-03-01 09:06:21.207130102 +0000
    @@ -1,6 +1,6 @@
     { mkDerivation, base, bytestring, containers, directory, fetchurl
    -, filepath, mtl, network-uri, pandoc-types, parsec, process, split
    -, syb, temporary, text, utf8-string, xml
    +, filepath, mtl, pandoc-types, parsec, process, split, syb
    +, temporary, text, utf8-string, xml
     }:
     mkDerivation {
       pname = "texmath";
    @@ -14,7 +14,6 @@
       libraryHaskellDepends = [
         base containers mtl pandoc-types parsec syb xml
       ];
    -  executableHaskellDepends = [ network-uri ];
       testHaskellDepends = [
         base bytestring directory filepath process split temporary text
         utf8-string xml
  test/golden-test-cases/text-icu.nix:                            OK
  test/golden-test-cases/text-postgresql.nix:                     OK
  test/golden-test-cases/th-expand-syns.nix:                      OK
  test/golden-test-cases/these.nix:                               OK
  test/golden-test-cases/timezone-series.nix:                     OK
  test/golden-test-cases/transformers-compat.nix:                 OK
  test/golden-test-cases/transformers-lift.nix:                   OK
  test/golden-test-cases/tree-fun.nix:                            OK
  test/golden-test-cases/ttrie.nix:                               OK
  test/golden-test-cases/tuple-th.nix:                            OK
  test/golden-test-cases/tuples-homogenous-h98.nix:               OK
  test/golden-test-cases/turtle-options.nix:                      OK
  test/golden-test-cases/type-operators.nix:                      OK
  test/golden-test-cases/type-spec.nix:                           OK
  test/golden-test-cases/unicode-show.nix:                        OK
  test/golden-test-cases/unique.nix:                              OK
  test/golden-test-cases/unix-bytestring.nix:                     OK
  test/golden-test-cases/unlit.nix:                               OK
  test/golden-test-cases/utility-ht.nix:                          OK
  test/golden-test-cases/validity-aeson.nix:                      OK
  test/golden-test-cases/regex-pcre.nix:                          OK
  test/golden-test-cases/relational-query.nix:                    OK
  test/golden-test-cases/relational-schemas.nix:                  OK
  test/golden-test-cases/repa-io.nix:                             OK
  test/golden-test-cases/repa.nix:                                OK
  test/golden-test-cases/rvar.nix:                                OK
  test/golden-test-cases/rosezipper.nix:                          OK
  test/golden-test-cases/scalpel-core.nix:                        OK
  test/golden-test-cases/sdl2.nix:                                OK
  test/golden-test-cases/selda-sqlite.nix:                        OK
  test/golden-test-cases/selda.nix:                               OK
  test/golden-test-cases/servant-checked-exceptions.nix:          FAIL
    --- test/golden-test-cases/servant-checked-exceptions.nix.golden    1970-01-01 00:00:01.000000000 +0000
    +++ test/golden-test-cases/servant-checked-exceptions.nix   2018-03-01 09:06:21.392130548 +0000
    @@ -1,8 +1,7 @@
     { mkDerivation, aeson, base, bytestring, deepseq, doctest, fetchurl
    -, Glob, hspec-wai, http-api-data, http-client, http-media
    -, natural-transformation, optparse-applicative, profunctors
    -, servant, servant-client, servant-docs, servant-server, tagged
    -, tasty, tasty-hspec, tasty-hunit, text, wai, warp
    +, Glob, hspec-wai, http-media, profunctors, servant, servant-client
    +, servant-docs, servant-server, tagged, tasty, tasty-hspec
    +, tasty-hunit, text, wai
     }:
     mkDerivation {
       pname = "servant-checked-exceptions";
    @@ -17,11 +16,6 @@
         aeson base bytestring deepseq http-media profunctors servant
         servant-client servant-docs servant-server tagged text
       ];
    -  executableHaskellDepends = [
    -    aeson base http-api-data http-client natural-transformation
    -    optparse-applicative servant servant-client servant-docs
    -    servant-server text wai warp
    -  ];
       testHaskellDepends = [
         base bytestring doctest Glob hspec-wai servant servant-server tasty
         tasty-hspec tasty-hunit wai
  test/golden-test-cases/set-cover.nix:                           OK (0.01s)
  test/golden-test-cases/sets.nix:                                OK
  test/golden-test-cases/simple-smt.nix:                          OK
  test/golden-test-cases/slack-web.nix:                           OK
  test/golden-test-cases/slug.nix:                                OK
  test/golden-test-cases/soxlib.nix:                              OK
  test/golden-test-cases/speedy-slice.nix:                        OK
  test/golden-test-cases/splice.nix:                              OK
  test/golden-test-cases/spreadsheet.nix:                         OK
  test/golden-test-cases/stack-type.nix:                          OK
  test/golden-test-cases/state-codes.nix:                         OK
  test/golden-test-cases/stb-image-redux.nix:                     OK
  test/golden-test-cases/stm-containers.nix:                      OK (0.01s)
  test/golden-test-cases/streaming-commons.nix:                   OK
  test/golden-test-cases/strict-base-types.nix:                   OK
  test/golden-test-cases/strict-types.nix:                        OK
  test/golden-test-cases/string-class.nix:                        OK
  test/golden-test-cases/stripe-haskell.nix:                      OK
  test/golden-test-cases/svg-tree.nix:                            OK
  test/golden-test-cases/swagger.nix:                             OK
  test/golden-test-cases/pinch.nix:                               OK
  test/golden-test-cases/pipes-network.nix:                       OK
  test/golden-test-cases/pipes-safe.nix:                          OK
  test/golden-test-cases/pointed.nix:                             OK
  test/golden-test-cases/poly-arity.nix:                          OK
  test/golden-test-cases/polynomials-bernstein.nix:               OK
  test/golden-test-cases/postgresql-simple-url.nix:               OK
  test/golden-test-cases/prelude-safeenum.nix:                    OK
  test/golden-test-cases/presburger.nix:                          OK
  test/golden-test-cases/prettyclass.nix:                         OK
  test/golden-test-cases/prettyprinter-compat-ansi-wl-pprint.nix: OK
  test/golden-test-cases/prettyprinter-compat-wl-pprint.nix:      OK
  test/golden-test-cases/primitive.nix:                           OK
  test/golden-test-cases/product-profunctors.nix:                 OK
  test/golden-test-cases/profiterole.nix:                         OK
  test/golden-test-cases/projectroot.nix:                         OK
  test/golden-test-cases/proto-lens-optparse.nix:                 OK
  test/golden-test-cases/proto-lens.nix:                          OK
  test/golden-test-cases/psqueues.nix:                            OK
  test/golden-test-cases/pusher-http-haskell.nix:                 OK
  test/golden-test-cases/quickcheck-arbitrary-adt.nix:            OK
  test/golden-test-cases/quickcheck-combinators.nix:              OK
  test/golden-test-cases/rank1dynamic.nix:                        OK
  test/golden-test-cases/rasterific-svg.nix:                      OK
  test/golden-test-cases/ratio-int.nix:                           OK
  test/golden-test-cases/rawstring-qm.nix:                        OK
  test/golden-test-cases/reactive-banana.nix:                     OK (0.01s)
  test/golden-test-cases/readline.nix:                            OK
  test/golden-test-cases/rebase.nix:                              OK (0.03s)
  test/golden-test-cases/reform-blaze.nix:                        OK
  test/golden-test-cases/reform-hsp.nix:                          OK
  test/golden-test-cases/regex-compat.nix:                        OK
  test/golden-test-cases/minio-hs.nix:                            OK (0.01s)
  test/golden-test-cases/mmorph.nix:                              OK
  test/golden-test-cases/mnist-idx.nix:                           OK
  test/golden-test-cases/mole.nix:                                OK
  test/golden-test-cases/monad-products.nix:                      OK
  test/golden-test-cases/monadcryptorandom.nix:                   OK
  test/golden-test-cases/monadloc.nix:                            OK
  test/golden-test-cases/mongoDB.nix:                             OK
  test/golden-test-cases/monoid-extras.nix:                       OK
  test/golden-test-cases/mwc-random-monad.nix:                    OK
  test/golden-test-cases/mwc-random.nix:                          FAIL
    --- test/golden-test-cases/mwc-random.nix.golden    1970-01-01 00:00:01.000000000 +0000
    +++ test/golden-test-cases/mwc-random.nix   2018-03-01 09:06:21.816131571 +0000
    @@ -1,6 +1,5 @@
    -{ mkDerivation, base, fetchurl, HUnit, math-functions, primitive
    -, QuickCheck, statistics, test-framework, test-framework-hunit
    -, test-framework-quickcheck2, time, vector
    +{ mkDerivation, base, fetchurl, math-functions, primitive, time
    +, vector
     }:
     mkDerivation {
       pname = "mwc-random";
    @@ -12,10 +11,6 @@
       libraryHaskellDepends = [
         base math-functions primitive time vector
       ];
    -  testHaskellDepends = [
    -    base HUnit QuickCheck statistics test-framework
    -    test-framework-hunit test-framework-quickcheck2 vector
    -  ];
       doCheck = false;
       homepage = "https://github.com/bos/mwc-random";
       description = "Fast, high quality pseudo random number generation";
  test/golden-test-cases/nanospec.nix:                            OK
  test/golden-test-cases/netpbm.nix:                              OK
  test/golden-test-cases/network-protocol-xmpp.nix:               OK
  test/golden-test-cases/network-transport-tcp.nix:               OK
  test/golden-test-cases/nix-paths.nix:                           OK
  test/golden-test-cases/nvim-hs.nix:                             OK
  test/golden-test-cases/once.nix:                                OK
  test/golden-test-cases/one-liner.nix:                           OK
  test/golden-test-cases/online.nix:                              OK
  test/golden-test-cases/openexr-write.nix:                       OK
  test/golden-test-cases/openpgp-asciiarmor.nix:                  OK
  test/golden-test-cases/pager.nix:                               OK
  test/golden-test-cases/partial-isomorphisms.nix:                OK
  test/golden-test-cases/partial-semigroup.nix:                   OK
  test/golden-test-cases/pathtype.nix:                            OK
  test/golden-test-cases/pcap.nix:                                OK
  test/golden-test-cases/pdfinfo.nix:                             OK
  test/golden-test-cases/pell.nix:                                OK
  test/golden-test-cases/persistable-types-HDBC-pg.nix:           OK
  test/golden-test-cases/persistent-mysql-haskell.nix:            OK
  test/golden-test-cases/picosat.nix:                             OK
  test/golden-test-cases/io-machine.nix:                          OK
  test/golden-test-cases/io-streams-haproxy.nix:                  OK
  test/golden-test-cases/ip.nix:                                  OK
  test/golden-test-cases/iso639.nix:                              OK
  test/golden-test-cases/iso8601-time.nix:                        OK
  test/golden-test-cases/jmacro-rpc-happstack.nix:                OK
  test/golden-test-cases/jmacro-rpc.nix:                          OK
  test/golden-test-cases/jose.nix:                                OK
  test/golden-test-cases/katip-elasticsearch.nix:                 OK
  test/golden-test-cases/katip.nix:                               OK
  test/golden-test-cases/katydid.nix:                             OK
  test/golden-test-cases/kawhi.nix:                               OK
  test/golden-test-cases/kraken.nix:                              OK
  test/golden-test-cases/l10n.nix:                                OK
  test/golden-test-cases/lambdabot-social-plugins.nix:            OK
  test/golden-test-cases/lazy-csv.nix:                            OK
  test/golden-test-cases/lens-aeson.nix:                          OK
  test/golden-test-cases/lens.nix:                                OK (0.02s)
  test/golden-test-cases/libgit.nix:                              OK
  test/golden-test-cases/librato.nix:                             OK
  test/golden-test-cases/lifted-async.nix:                        OK
  test/golden-test-cases/lmdb.nix:                                OK
  test/golden-test-cases/logging-effect-extra-file.nix:           OK
  test/golden-test-cases/lucid.nix:                               OK
  test/golden-test-cases/mainland-pretty.nix:                     OK
  test/golden-test-cases/matrices.nix:                            OK
  test/golden-test-cases/median-stream.nix:                       OK
  test/golden-test-cases/megaparsec.nix:                          OK
  test/golden-test-cases/mersenne-random.nix:                     OK
  test/golden-test-cases/messagepack.nix:                         OK
  test/golden-test-cases/microlens-ghc.nix:                       OK
  test/golden-test-cases/microlens.nix:                           OK
  test/golden-test-cases/happy.nix:                               OK
  test/golden-test-cases/harp.nix:                                OK
  test/golden-test-cases/hashtables.nix:                          OK (0.01s)
  test/golden-test-cases/haskell-tools-debug.nix:                 OK
  test/golden-test-cases/haskell-tools-rewrite.nix:               OK
  test/golden-test-cases/hasql.nix:                               OK
  test/golden-test-cases/hformat.nix:                             OK
  test/golden-test-cases/highlighting-kate.nix:                   FAIL (0.01s)
    --- test/golden-test-cases/highlighting-kate.nix.golden     1970-01-01 00:00:01.000000000 +0000
    +++ test/golden-test-cases/highlighting-kate.nix    2018-03-01 09:06:22.211132525 +0000
    @@ -15,7 +15,6 @@
         base blaze-html containers mtl parsec regex-pcre-builtin
         utf8-string
       ];
    -  executableHaskellDepends = [ base blaze-html containers filepath ];
       testHaskellDepends = [
         base blaze-html containers Diff directory filepath process
       ];
  test/golden-test-cases/hit.nix:                                 OK
  test/golden-test-cases/hjson.nix:                               OK
  test/golden-test-cases/hmpfr.nix:                               OK
  test/golden-test-cases/hoogle.nix:                              OK
  test/golden-test-cases/hostname-validate.nix:                   OK
  test/golden-test-cases/hsinstall.nix:                           OK
  test/golden-test-cases/hstatsd.nix:                             OK
  test/golden-test-cases/hsx-jmacro.nix:                          OK
  test/golden-test-cases/hsyslog.nix:                             OK
  test/golden-test-cases/htoml.nix:                               OK
  test/golden-test-cases/http-conduit.nix:                        OK
  test/golden-test-cases/http-link-header.nix:                    OK
  test/golden-test-cases/http-media.nix:                          OK
  test/golden-test-cases/hxt-charproperties.nix:                  OK
  test/golden-test-cases/hxt-expat.nix:                           OK
  test/golden-test-cases/hxt-tagsoup.nix:                         OK
  test/golden-test-cases/iconv.nix:                               OK
  test/golden-test-cases/incremental-parser.nix:                  OK
  test/golden-test-cases/indentation-core.nix:                    OK
  test/golden-test-cases/indentation-parsec.nix:                  OK
  test/golden-test-cases/inline-c-cpp.nix:                        OK
  test/golden-test-cases/integer-logarithms.nix:                  OK
  test/golden-test-cases/intero.nix:                              OK
  test/golden-test-cases/invariant.nix:                           OK
  test/golden-test-cases/genvalidity-hspec-aeson.nix:             OK
  test/golden-test-cases/genvalidity-hspec-binary.nix:            OK
  test/golden-test-cases/genvalidity-scientific.nix:              OK
  test/golden-test-cases/genvalidity-uuid.nix:                    OK
  test/golden-test-cases/ghc-syb-utils.nix:                       OK
  test/golden-test-cases/ghcid.nix:                               OK
  test/golden-test-cases/giphy-api.nix:                           FAIL
    --- test/golden-test-cases/giphy-api.nix.golden     1970-01-01 00:00:01.000000000 +0000
    +++ test/golden-test-cases/giphy-api.nix    2018-03-01 09:06:22.411133007 +0000
    @@ -17,7 +17,6 @@
         microlens microlens-th mtl network-uri servant servant-client text
         transformers
       ];
    -  executableHaskellDepends = [ base network-uri text ];
       testHaskellDepends = [
         aeson base basic-prelude bytestring containers directory hspec lens
         network-uri text
  test/golden-test-cases/github.nix:                              OK
  test/golden-test-cases/gl.nix:                                  OK (0.13s)
  test/golden-test-cases/gogol-adexchange-buyer.nix:              OK
  test/golden-test-cases/gogol-admin-emailmigration.nix:          OK
  test/golden-test-cases/gogol-affiliates.nix:                    OK
  test/golden-test-cases/gogol-apps-tasks.nix:                    OK
  test/golden-test-cases/gogol-appstate.nix:                      OK
  test/golden-test-cases/gogol-blogger.nix:                       OK
  test/golden-test-cases/gogol-datastore.nix:                     OK
  test/golden-test-cases/gogol-dfareporting.nix:                  OK (0.02s)
  test/golden-test-cases/gogol-firebase-rules.nix:                OK
  test/golden-test-cases/gogol-gmail.nix:                         OK
  test/golden-test-cases/gogol-kgsearch.nix:                      OK
  test/golden-test-cases/gogol-maps-engine.nix:                   OK
  test/golden-test-cases/gogol-plus.nix:                          OK
  test/golden-test-cases/gogol-resourceviews.nix:                 OK
  test/golden-test-cases/gogol-translate.nix:                     OK
  test/golden-test-cases/gogol-webmaster-tools.nix:               OK
  test/golden-test-cases/gogol-youtube.nix:                       OK
  test/golden-test-cases/groundhog-mysql.nix:                     OK
  test/golden-test-cases/gsasl.nix:                               OK
  test/golden-test-cases/hOpenPGP.nix:                            OK
  test/golden-test-cases/hPDB-examples.nix:                       OK
  test/golden-test-cases/hakyll.nix:                              OK
  test/golden-test-cases/happstack-hsp.nix:                       OK
  test/golden-test-cases/data-msgpack.nix:                        OK
  test/golden-test-cases/data-serializer.nix:                     OK
  test/golden-test-cases/deque.nix:                               OK
  test/golden-test-cases/dhall-bash.nix:                          OK
  test/golden-test-cases/diagrams-solve.nix:                      OK
  test/golden-test-cases/discrimination.nix:                      OK
  test/golden-test-cases/dotenv.nix:                              OK
  test/golden-test-cases/dotnet-timespan.nix:                     OK
  test/golden-test-cases/dpor.nix:                                OK
  test/golden-test-cases/drawille.nix:                            OK
  test/golden-test-cases/drifter-postgresql.nix:                  OK
  test/golden-test-cases/ede.nix:                                 OK
  test/golden-test-cases/ekg-cloudwatch.nix:                      OK
  test/golden-test-cases/emailaddress.nix:                        OK
  test/golden-test-cases/envelope.nix:                            OK
  test/golden-test-cases/eventful-sqlite.nix:                     OK
  test/golden-test-cases/exact-pi.nix:                            OK
  test/golden-test-cases/expiring-cache-map.nix:                  OK
  test/golden-test-cases/explicit-exception.nix:                  OK
  test/golden-test-cases/fdo-notify.nix:                          OK
  test/golden-test-cases/fgl.nix:                                 OK
  test/golden-test-cases/file-modules.nix:                        OK
  test/golden-test-cases/fingertree.nix:                          OK
  test/golden-test-cases/fixed-vector.nix:                        OK
  test/golden-test-cases/fixed.nix:                               OK
  test/golden-test-cases/foundation.nix:                          OK (0.01s)
  test/golden-test-cases/frisby.nix:                              OK
  test/golden-test-cases/funcmp.nix:                              OK
  test/golden-test-cases/functor-classes-compat.nix:              OK
  test/golden-test-cases/general-games.nix:                       OK
  test/golden-test-cases/generic-lens.nix:                        OK
  test/golden-test-cases/genvalidity-aeson.nix:                   OK
  test/golden-test-cases/bindings-uname.nix:                      OK
  test/golden-test-cases/bioalign.nix:                            OK
  test/golden-test-cases/bits.nix:                                OK
  test/golden-test-cases/blank-canvas.nix:                        OK
  test/golden-test-cases/blaze-html.nix:                          OK
  test/golden-test-cases/blaze-markup.nix:                        OK
  test/golden-test-cases/blaze-svg.nix:                           OK
  test/golden-test-cases/blosum.nix:                              OK
  test/golden-test-cases/boomerang.nix:                           OK
  test/golden-test-cases/boxes.nix:                               OK
  test/golden-test-cases/brittany.nix:                            OK (0.01s)
  test/golden-test-cases/broadcast-chan.nix:                      OK
  test/golden-test-cases/butcher.nix:                             FAIL
    --- test/golden-test-cases/butcher.nix.golden       1970-01-01 00:00:01.000000000 +0000
    +++ test/golden-test-cases/butcher.nix      2018-03-01 09:06:22.980134379 +0000
    @@ -13,10 +13,6 @@
         base bifunctors containers deque either extra free microlens
         microlens-th mtl multistate pretty transformers unsafe void
       ];
    -  testHaskellDepends = [
    -    base containers deque either extra free microlens microlens-th mtl
    -    multistate pretty transformers unsafe
    -  ];
       homepage = "https://github.com/lspitzner/butcher/";
       description = "Chops a command or program invocation into digestable pieces";
       license = stdenv.lib.licenses.bsd3;
  test/golden-test-cases/bzlib.nix:                               OK
  test/golden-test-cases/case-insensitive.nix:                    OK
  test/golden-test-cases/cassava-conduit.nix:                     OK
  test/golden-test-cases/cassette.nix:                            OK
  test/golden-test-cases/cereal-text.nix:                         OK
  test/golden-test-cases/cheapskate.nix:                          OK
  test/golden-test-cases/chell.nix:                               OK
  test/golden-test-cases/clumpiness.nix:                          OK
  test/golden-test-cases/code-page.nix:                           OK
  test/golden-test-cases/colorize-haskell.nix:                    OK
  test/golden-test-cases/countable.nix:                           OK
  test/golden-test-cases/cpu.nix:                                 OK
  test/golden-test-cases/criterion.nix:                           OK
  test/golden-test-cases/crypt-sha512.nix:                        OK
  test/golden-test-cases/crypto-random-api.nix:                   OK
  test/golden-test-cases/csv.nix:                                 OK
  test/golden-test-cases/data-accessor.nix:                       OK
  test/golden-test-cases/data-default-instances-containers.nix:   OK
  test/golden-test-cases/data-endian.nix:                         OK
  test/golden-test-cases/QuickCheck.nix:                          OK
  test/golden-test-cases/ReadArgs.nix:                            OK
  test/golden-test-cases/SHA.nix:                                 FAIL
    --- test/golden-test-cases/SHA.nix.golden   1970-01-01 00:00:01.000000000 +0000
    +++ test/golden-test-cases/SHA.nix  2018-03-01 09:06:23.088134640 +0000
    @@ -1,5 +1,5 @@
    -{ mkDerivation, array, base, binary, bytestring, directory
    -, fetchurl, QuickCheck, test-framework, test-framework-quickcheck2
    +{ mkDerivation, array, base, binary, bytestring, fetchurl
    +, QuickCheck, test-framework, test-framework-quickcheck2
     }:
     mkDerivation {
       pname = "SHA";
    @@ -11,7 +11,6 @@
       isLibrary = true;
       isExecutable = true;
       libraryHaskellDepends = [ array base binary bytestring ];
    -  executableHaskellDepends = [ base bytestring directory ];
       testHaskellDepends = [
         array base binary bytestring QuickCheck test-framework
         test-framework-quickcheck2
  test/golden-test-cases/Strafunski-StrategyLib.nix:              OK
  test/golden-test-cases/accelerate-fftw.nix:                     OK
  test/golden-test-cases/accelerate.nix:                          OK
  test/golden-test-cases/active.nix:                              OK
  test/golden-test-cases/adjunctions.nix:                         OK
  test/golden-test-cases/aeson-diff.nix:                          OK
  test/golden-test-cases/aeson-pretty.nix:                        OK
  test/golden-test-cases/algebraic-graphs.nix:                    OK
  test/golden-test-cases/amazonka-cloudtrail.nix:                 OK
  test/golden-test-cases/amazonka-cloudwatch-logs.nix:            OK
  test/golden-test-cases/amazonka-codedeploy.nix:                 OK
  test/golden-test-cases/amazonka-cognito-idp.nix:                OK (0.01s)
  test/golden-test-cases/amazonka-ecs.nix:                        OK
  test/golden-test-cases/amazonka-kms.nix:                        OK
  test/golden-test-cases/amazonka-lightsail.nix:                  OK
  test/golden-test-cases/amazonka-route53-domains.nix:            OK
  test/golden-test-cases/amazonka-waf.nix:                        OK
  test/golden-test-cases/api-field-json-th.nix:                   OK
  test/golden-test-cases/app-settings.nix:                        OK
  test/golden-test-cases/apply-refact.nix:                        OK
  test/golden-test-cases/async.nix:                               OK
  test/golden-test-cases/attoparsec-expr.nix:                     OK
  test/golden-test-cases/attoparsec-time.nix:                     OK
  test/golden-test-cases/avers-server.nix:                        OK
  test/golden-test-cases/aws.nix:                                 OK
  test/golden-test-cases/bbdb.nix:                                OK
  test/golden-test-cases/benchpress.nix:                          OK
  test/golden-test-cases/binary-bits.nix:                         OK
  test/golden-test-cases/binary-tagged.nix:                       OK (0.01s)
  test/golden-test-cases/ChasingBottoms.nix:                      OK
  test/golden-test-cases/Clipboard.nix:                           OK
  test/golden-test-cases/FenwickTree.nix:                         OK
  test/golden-test-cases/GPipe-GLFW.nix:                          OK
  test/golden-test-cases/GenericPretty.nix:                       OK
  test/golden-test-cases/HPDF.nix:                                OK
  test/golden-test-cases/HTF.nix:                                 OK (0.01s)
  test/golden-test-cases/HTTP.nix:                                OK
  test/golden-test-cases/Hclip.nix:                               OK
  test/golden-test-cases/MissingH.nix:                            OK
  test/golden-test-cases/ObjectName.nix:                          OK
  test/golden-test-cases/Only.nix:                                OK
  test/golden-test-cases/QuasiText.nix:                           OK
```