### PR TITLE
Compatibility with Cabal 2.2 and hpack 2.28

### DIFF
--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -127,8 +127,10 @@ library
     , time
     , transformers
     , yaml
+    , utf8-string
   exposed-modules:
       Cabal2nix
+      Distribution.Nixpkgs.CabalCompat
       Distribution.Nixpkgs.Fetch
       Distribution.Nixpkgs.Haskell
       Distribution.Nixpkgs.Haskell.BuildInfo

--- a/hackage2nix/HackageGit.hs
+++ b/hackage2nix/HackageGit.hs
@@ -12,11 +12,11 @@ import Data.Map as Map
 import Data.Set as Set
 import Data.String
 import Data.String.UTF8 ( toString, fromRep )
+import Distribution.Nixpkgs.CabalCompat
 import Distribution.Nixpkgs.Hashes
 import Distribution.Nixpkgs.Haskell.OrphanInstances ( )
 import Distribution.Package
 import Distribution.PackageDescription
-import Distribution.PackageDescription.Parse ( parseGenericPackageDescription, ParseResult(..) )
 import Distribution.Text
 import Distribution.Version
 import OpenSSL.Digest ( digest, digestByName )
@@ -47,9 +47,9 @@ readPackage :: FilePath -> PackageIdentifier -> IO (GenericPackageDescription, S
 readPackage dirPrefix (PackageIdentifier name version) = do
   let cabalFile = dirPrefix </> unPackageName name </> display version </> unPackageName name <.> "cabal"
   buf <- BS.readFile cabalFile
-  cabal <- case parseGenericPackageDescription (decodeUTF8 buf) of
-             ParseOk _ a  -> return a
-             ParseFailed err -> fail (cabalFile ++ ": " ++ show err)
+  cabal <- case parseGenericPackageDescription buf of
+             Right a  -> return a
+             Left err -> fail (cabalFile ++ ": " ++ err)
   return (cabal, printSHA256 (digest (digestByName "sha256") buf))
 
 declareLenses [d|

--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -16,6 +16,7 @@ import Data.String
 import Data.Time
 import qualified Distribution.Compat.ReadP as P
 import Distribution.Compiler
+import Distribution.Nixpkgs.CabalCompat
 import Distribution.Nixpkgs.Fetch
 import Distribution.Nixpkgs.Haskell
 import Distribution.Nixpkgs.Haskell.FromCabal
@@ -211,6 +212,6 @@ cabal2nix args = do
     Right d -> pPrint d
 
 readFlagList :: [String] -> FlagAssignment
-readFlagList = map tagWithValue
+readFlagList = mkFlagAssignment . map tagWithValue
   where tagWithValue ('-':fname) = (mkFlagName (lowercase fname), False)
         tagWithValue fname       = (mkFlagName (lowercase fname), True)

--- a/src/Distribution/Nixpkgs/CabalCompat.hs
+++ b/src/Distribution/Nixpkgs/CabalCompat.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE CPP #-}
+
+module Distribution.Nixpkgs.CabalCompat
+  ( unFlagAssignment
+  , mkFlagAssignment
+  , parseGenericPackageDescription
+  ) where
+
+-- Parser
+import qualified Data.ByteString.Char8 as BS
+#if MIN_VERSION_Cabal(2,2,0)
+import qualified Distribution.PackageDescription.Parsec as Cabal
+#else
+import qualified Distribution.PackageDescription.Parser as Cabal
+import Data.String.UTF8 ( toString, fromRep )
+#endif
+
+-- FlagAssignment
+import Distribution.PackageDescription ( GenericPackageDescription )
+#if MIN_VERSION_Cabal(2,2,0)
+import Distribution.PackageDescription ( mkFlagAssignment, unFlagAssignment )
+#else
+import Distribution.PackageDescription ( FlagAssignment )
+#endif
+
+#if !MIN_VERSION_Cabal(2,2,0)
+unFlagAssignment :: FlagAssignment -> [(FlagName, Bool)]
+unFlagAssignment = id
+
+mkFlagAssignment :: [(FlagName, Bool)] -> FlagAssignment
+mkFlagAssignment = id
+#endif
+
+parseGenericPackageDescription :: BS.ByteString -> Either String GenericPackageDescription
+#if MIN_VERSION_Cabal(2,2,0)
+parseGenericPackageDescription bs =
+    case Cabal.runParseResult $ Cabal.parseGenericPackageDescription bs of
+      (_, Left (_, errs)) -> Left $ show errs
+      (_, Right x)        -> Right x
+#else
+parseGenericPackageDescription bs =
+    case Cabal.parseGenericPackageDescription (decodeUTF8 bs) of
+      (ParseFailed err) -> Left err
+      (ParseOk _ x)     -> Right x
+  where
+    decodeUTF8 :: ByteString -> String
+    decodeUTF8 = toString . fromRep
+#endif

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs
@@ -9,7 +9,10 @@ import Distribution.PackageDescription
 import Distribution.Version
 
 configureCabalFlags :: PackageIdentifier -> FlagAssignment
-configureCabalFlags (PackageIdentifier name version)
+configureCabalFlags = mkFlagAssignment . configureCabalFlags'
+
+configureCabalFlags' :: PackageIdentifier -> [(FlagName, Bool)]
+configureCabalFlags' (PackageIdentifier name version)
  | name == "accelerate-examples"= [disable "opencl"]
  | name == "arithmoi"           = [disable "llvm"]
  | name == "cassava"            = [disable "bytestring--lt-0_10_4"]

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Normalize.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Normalize.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Distribution.Nixpkgs.Haskell.FromCabal.Normalize ( normalize, normalizeCabalFlags ) where
@@ -7,6 +8,7 @@ import Data.Function
 import Data.List
 import qualified Data.Set as Set
 import Data.String
+import Distribution.Nixpkgs.CabalCompat
 import Distribution.Nixpkgs.Haskell
 import Distribution.Nixpkgs.Meta
 import Distribution.Package
@@ -55,6 +57,7 @@ quote []          = []
 -- [(FlagName "foo",True)]
 
 normalizeCabalFlags :: FlagAssignment -> FlagAssignment
-normalizeCabalFlags flags' = nubBy ((==) `on` fst) (sortBy (compare `on` fst) flags)
+normalizeCabalFlags flags' =
+    mkFlagAssignment $ nubBy ((==) `on` fst) (sortBy (compare `on` fst) flags)
   where
-    flags = [ (mkFlagName (lowercase (unFlagName n)), b) | (n, b) <- flags' ]
+    flags = [ (mkFlagName (lowercase (unFlagName n)), b) | (n, b) <- unFlagAssignment flags' ]

--- a/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
+++ b/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Distribution.Nixpkgs.Haskell.OrphanInstances ( ) where
@@ -8,11 +9,13 @@ import Data.String
 import qualified Data.Text as T
 import Data.Yaml
 import Distribution.Compiler
-import Distribution.License
 import Distribution.Package
-import Distribution.PackageDescription
 import Distribution.System
 import Distribution.Text
+import Distribution.Version
+#if !MIN_VERSION_Cabal(2,2,0)
+import Distribution.License
+import Distribution.PackageDescription
 import Distribution.Types.CondTree
 import Distribution.Types.ExecutableScope
 import Distribution.Types.ForeignLib
@@ -20,9 +23,12 @@ import Distribution.Types.ForeignLibOption
 import Distribution.Types.ForeignLibType
 import Distribution.Types.IncludeRenaming
 import Distribution.Types.Mixin
-import Distribution.Version
 import Language.Haskell.Extension
+#endif
 
+instance NFData CompilerInfo
+instance NFData AbiTag
+#if !MIN_VERSION_Cabal(2,2,0)
 instance NFData SetupBuildInfo
 instance (NFData v, NFData c, NFData a) => NFData (CondTree v c a)
 instance (NFData v, NFData c, NFData a) => NFData (CondBranch v c a)
@@ -62,9 +68,8 @@ instance NFData TestSuiteInterface
 instance NFData TestType
 instance NFData a => NFData (Condition a)
 instance NFData Platform
-instance NFData CompilerInfo
 instance NFData CompilerId
-instance NFData AbiTag
+#endif
 
 instance IsString Version where
   fromString = text2isString "Version"


### PR DESCRIPTION
This introduces compatibility with `Cabal` 2.2 and `hpack` 2.28. There were a few interesting changes:
 * `Cabal`'s `FlagAssignment` is now a distinct type
 * `Cabal` now has a new `parsec`-based package description parser
 * `Cabal` now provides various `NFData` instances which were previously defined as orphans.
 * `Cabal`'s licenses are now given as SPDX names
 * `hpack` refactored various interfaces

Compatibility with older `Cabal` releases has been preserved.