### PR TITLE
WIP: CC0-1.0 is now a known license

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -35,7 +35,7 @@ fromCabalLicense (Apache Nothing)                          = Known "stdenv.lib.l
 fromCabalLicense (Apache (Just (versionNumbers -> [2,0]))) = Known "stdenv.lib.licenses.asl20"
 fromCabalLicense ISC                                       = Known "stdenv.lib.licenses.isc"
 fromCabalLicense OtherLicense                              = Unknown Nothing
-fromCabalLicense CC0-1.0                                   = Known "stdenv.lib.licenses.cc0"
+fromCabalLicense CC0_1_0                                   = Known "stdenv.lib.licenses.cc0"
 fromCabalLicense (UnknownLicense "CC0-1.0")                = Known "stdenv.lib.licenses.cc0"
 fromCabalLicense l                                         = error $ "Distribution.Nixpkgs.Haskell.FromCabal.License.fromCabalLicense: unknown license"
                                                                   ++ show l ++"\nChoose one of: " ++ intercalate ", " (map display knownLicenses)

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -35,6 +35,7 @@ fromCabalLicense (Apache Nothing)                          = Known "stdenv.lib.l
 fromCabalLicense (Apache (Just (versionNumbers -> [2,0]))) = Known "stdenv.lib.licenses.asl20"
 fromCabalLicense ISC                                       = Known "stdenv.lib.licenses.isc"
 fromCabalLicense OtherLicense                              = Unknown Nothing
+fromCabalLicense CC0-1.0                                   = Known "stdenv.lib.licenses.cc0"
 fromCabalLicense (UnknownLicense "CC0-1.0")                = Known "stdenv.lib.licenses.cc0"
 fromCabalLicense l                                         = error $ "Distribution.Nixpkgs.Haskell.FromCabal.License.fromCabalLicense: unknown license"
                                                                   ++ show l ++"\nChoose one of: " ++ intercalate ", " (map display knownLicenses)


### PR DESCRIPTION
In the cabal 2.2.0.0 they stopped allowing PublicDomain licenses to be uploaded to Hackage and CC0-1.0 is a  known license now. https://www.reddit.com/r/haskell/comments/87t7nn/releasing_packages_as_public_domain_creative/