### PR TITLE
fetchOrFromDB: Show which source failed when calling `fail`

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -71,7 +71,7 @@ fetchOrFromDB optHpack hackageDB src
   | otherwise                             = do
     r <- fetch (\dir -> cabalFromPath optHpack (dir </> sourceCabalDir src)) src
     case r of
-      Nothing -> fail "Failed to fetch source. Does the URL exist?"
+      Nothing -> fail $ "Failed to fetch source. Does this source exist? " ++ show src
       Just (derivSource, (externalSource, ranHpack, pkgDesc)) ->
         return (derivSource <$ guard externalSource, ranHpack, pkgDesc)
 


### PR DESCRIPTION
Note I haven't built this because I could find neither instructions against which nixpkgs I should best build this nor a `stack.yaml` so I'll just leave it here relying on your goodwill to typecheck it for me @peti :-)