### PR TITLE
Refactor cabal2nix lib api

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -62,9 +62,9 @@ data Options = Options
   , optSystem :: Platform
   , optSubpath :: Maybe FilePath
   , optHackageSnapshot :: Maybe UTCTime
+  , optNixpkgsIdentifier :: NixpkgsResolver
   , optUrl :: String
   }
-  deriving (Show)
 
 options :: Parser Options
 options = Options
@@ -88,6 +88,7 @@ options = Options
           <*> option (maybeReader parsePlatform) (long "system" <> help "host system (in either short Nix format or full LLVM style) to use when evaluating the Cabal file" <> value buildPlatform <> showDefaultWith display)
           <*> optional (strOption $ long "subpath" <> metavar "PATH" <> help "Path to Cabal file's directory relative to the URI (default is root directory)")
           <*> optional (option utcTimeReader (long "hackage-snapshot" <> help "hackage snapshot time, ISO format"))
+          <*> pure (\i -> Just (binding # (i, path # [i])))
           <*> strArgument (metavar "URI")
 
 -- | A parser for the date. Hackage updates happen maybe once or twice a month.
@@ -207,7 +208,7 @@ processPackage Options{..} pkg = do
 
       deriv :: Derivation
       deriv = withHpackOverrides $ fromGenericPackageDescription (const True)
-                                            (\i -> Just (binding # (i, path # [i])))
+                                            optNixpkgsIdentifier
                                             optSystem
                                             (unknownCompilerInfo optCompiler NoAbiTag)
                                             flags

--- a/src/Distribution/Nixpkgs/Haskell/Hackage.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Hackage.hs
@@ -1,6 +1,6 @@
 module Distribution.Nixpkgs.Haskell.Hackage
   ( HackageDB, PackageData, VersionData(..)
-  , hackageTarball, readTarball
+  , hackageTarball, readTarball, parsePackageData
   )
   where
 


### PR DESCRIPTION
1) Changes previous:

```haskell
cabal2nix' :: [String] -> IO (Either Doc Derivation)
cabal2nixWithDB :: DB.HackageDB -> [String] -> IO (Either Doc Derivation)
```
into more typed

```haskell
cabal2nix' :: Options -> IO (Either Doc Derivation)
cabal2nixWithDB :: DB.HackageDB -> Options -> IO (Either Doc Derivation)
parseArgs :: [String] -> IO Options
```

2) Allows setting nixpkgs identifier with `Options`

3) Exposes a function to ease use of Distribution.Nixpkgs.Haskell.Hackage module

These changes are required to make next release of https://github.com/input-output-hk/stack2nix