### PR TITLE
libNixName: map tensorflow to libtensorflow

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
@@ -143,6 +143,7 @@ libNixName "stdc++.dll"                         = [] -- What is that?
 libNixName "systemd-journal"                    = return "systemd"
 libNixName "tag_c"                              = return "taglib"
 libNixName "taglib_c"                           = return "taglib"
+libNixName "tensorflow"                         = return "libtensorflow"
 libNixName "udev"                               = return "systemd";
 libNixName "uuid"                               = return "libossp_uuid";
 libNixName "wayland-client"                     = return "wayland"


### PR DESCRIPTION
This patch produces the following correct derivation. This now works because nixpkgs recently [gained the `libtensorflow` attribute](https://github.com/NixOS/nixpkgs/commit/1c48e89eb138c75ca8ebf95a6aa13078c03be9d5#diff-036410e9211b4336186fc613f7200b12R863).

```
$ dist/build/cabal2nix/cabal2nix cabal://tensorflow
{ mkDerivation, async, attoparsec, base, bytestring, c2hs
, containers, data-default, exceptions, fgl, HUnit, lens-family
, libtensorflow, mainland-pretty, mtl, proto-lens
, proto-lens-protoc, semigroups, split, stdenv, temporary
, tensorflow-proto, test-framework, test-framework-hunit
, test-framework-quickcheck2, text, transformers, vector
}:
mkDerivation {
  pname = "tensorflow";
  version = "0.1.0.2";
  sha256 = "13b08d98cea0bde47b2e2ed9bc51937add0708eb50ef06e504100a447be92d50";
  libraryHaskellDepends = [
    async attoparsec base bytestring containers data-default exceptions
    fgl lens-family mainland-pretty mtl proto-lens proto-lens-protoc
    semigroups split temporary tensorflow-proto text transformers
    vector
  ];
  librarySystemDepends = [ libtensorflow ];
  libraryToolDepends = [ c2hs ];
  testHaskellDepends = [
    attoparsec base bytestring HUnit lens-family proto-lens
    tensorflow-proto test-framework test-framework-hunit
    test-framework-quickcheck2
  ];
  homepage = "https://github.com/tensorflow/haskell#readme";
  description = "TensorFlow bindings";
  license = stdenv.lib.licenses.asl20;
}
```