### PR TITLE
Update error message for unresolved constraints

### DIFF
--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -193,7 +193,10 @@ enforcePreferredVersions cs pkg = Set.filter (\v -> PackageIdentifier pkg v `sat
 
 resolveConstraint :: Constraint -> Hackage -> Version
 resolveConstraint c = fromMaybe (error msg) . resolveConstraint' c
-  where msg = "constraint " ++ display c ++ " cannot be resolved in Hackage"
+  where msg = unlines [ "constraint " ++ display c ++ " cannot be resolved in Hackage"
+                      , "This could be due the package being missing in the hackage directory"
+                      , "or the file system not being case sensitive."
+                      ]
 
 resolveConstraint' :: Constraint -> Hackage -> Maybe Version
 resolveConstraint' (Dependency name vrange) hackage


### PR DESCRIPTION
Hi all,

This tiny patch just updates an error message to highlight the line in the [README](https://github.com/NixOS/cabal2nix/blob/master/hackage2nix/README.md) about using a case-sensitive file system.

I got this error while trying to use hackage2nix:
```
hackage2nix: constraint cassava ==0.5.1.0 cannot be resolved in Hackage
```
and like a fool I tried other things before realising I had skipped that part 😄 

Thanks!