### PR TITLE
Add --no-submodules option to suppress fetching submodules (e.g. git).

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -91,7 +91,7 @@ options = Options
           <*> optional (option utcTimeReader (long "hackage-snapshot" <> help "hackage snapshot time, ISO format"))
           <*> pure (\i -> Just (binding # (i, path # [ident # "pkgs", i])))
           <*> strArgument (metavar "URI")
-          <*> flag True False (long "no-submodules" <> help "don't fetch git submodules")
+          <*> flag True False (long "dont-fetch-submodules" <> help "do not fetch git submodules from git sources")
 
 -- | A parser for the date. Hackage updates happen maybe once or twice a month.
 -- Example: parseTime defaultTimeLocale "%FT%T%QZ" "2017-11-20T12:18:35Z" :: Maybe UTCTime

--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -64,6 +64,7 @@ data Options = Options
   , optHackageSnapshot :: Maybe UTCTime
   , optNixpkgsIdentifier :: NixpkgsResolver
   , optUrl :: String
+  , optFetchSubmodules :: Bool
   }
 
 options :: Parser Options
@@ -90,6 +91,7 @@ options = Options
           <*> optional (option utcTimeReader (long "hackage-snapshot" <> help "hackage snapshot time, ISO format"))
           <*> pure (\i -> Just (binding # (i, path # [ident # "pkgs", i])))
           <*> strArgument (metavar "URI")
+          <*> flag True False (long "no-submodules" <> help "don't fetch git submodules")
 
 -- | A parser for the date. Hackage updates happen maybe once or twice a month.
 -- Example: parseTime defaultTimeLocale "%FT%T%QZ" "2017-11-20T12:18:35Z" :: Maybe UTCTime
@@ -187,14 +189,16 @@ hpackOverrides = over phaseOverrides (++ "preConfigure = \"hpack\";")
 
 cabal2nix' :: Options -> IO (Either Doc Derivation)
 cabal2nix' opts@Options{..} = do
-  pkg <- getPackage optHpack optHackageDb optHackageSnapshot $ Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
+  pkg <- getPackage optHpack optFetchSubmodules optHackageDb optHackageSnapshot $
+         Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
   processPackage opts pkg
 
 cabal2nixWithDB :: DB.HackageDB -> Options -> IO (Either Doc Derivation)
 cabal2nixWithDB db opts@Options{..} = do
   when (isJust optHackageDb) $ hPutStrLn stderr "WARN: HackageDB provided directly; ignoring --hackage-db"
   when (isJust optHackageSnapshot) $ hPutStrLn stderr "WARN: HackageDB provided directly; ignoring --hackage-snapshot"
-  pkg <- getPackage' optHpack (return db) $ Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
+  pkg <- getPackage' optHpack optFetchSubmodules (return db) $
+         Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
   processPackage opts pkg
 
 processPackage :: Options -> Package -> IO (Either Doc Derivation)

--- a/src/Distribution/Nixpkgs/Fetch.hs
+++ b/src/Distribution/Nixpkgs/Fetch.hs
@@ -79,11 +79,11 @@ fetch :: forall a.
                                                 -- This is required, because we cannot always check if a download succeeded otherwise.
       -> Source                                 -- ^ The source to fetch from.
       -> IO (Maybe (DerivationSource, a))       -- ^ The derivation source and the result of the processing function. Returns Nothing if the download failed.
-fetch s f = runMaybeT . fetchers where
+fetch optSubModules f = runMaybeT . fetchers where
   fetchers :: Source -> MaybeT IO (DerivationSource, a)
   fetchers source = msum . (fetchLocal source :) $ map (\fetcher -> fetchWith fetcher source >>= process)
     [ (False, "url", [])
-    , (True, "git", if s then ["--fetch-submodules"] else [])
+    , (True, "git", ["--fetch-submodules" | optSubModules ])
     , (True, "hg", [])
     , (True, "svn", [])
     , (True, "bzr", [])


### PR DESCRIPTION
There are times when submodule fetching is unnecessary (e.g. the submodules will be built as separate nix packages), so it would be nice to suppress this for git repos with extensive or recursive submodules.  This patch leaves the default behavior to fetch the submodules, but adds an option to disable that.

    $ diff <(time cabal2nix https://github.com/GaloisInc/macaw-semmc --subpath macaw-semmc 2> /dev/null) \
           <(time cabal2nix https://github.com/GaloisInc/macaw-semmc --subpath macaw-semmc --no-submodules 2> /dev/null)
    
    real    0m2.169s
    user    0m0.105s
    sys     0m0.037s

    real    1m16.636s
    user    0m6.695s
    sys     0m1.449s
    11c11
    <     sha256 = "16gmdhxn92qxpqlx2p2bd4cg1zpjsv5qa8hf4riymsifndrfcnvx";
    ---
    >     sha256 = "0yc5y9vcvkri2cj5mma37jca07srlm8h089pqrq9zh9g63aa1b9w";
    $