### PR TITLE
Output fetchSubmodules setting in src directive

### DIFF
--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -151,7 +151,7 @@ main = do
 
           drv :: Derivation
           drv = fromGenericPackageDescription haskellResolver nixpkgsResolver targetPlatform (compilerInfo config) flagAssignment [] descr
-                  & src .~ DerivationSource "url" ("mirror://hackage/" ++ display pkgId ++ ".tar.gz") "" tarballSHA256
+                  & src .~ urlDerivationSource ("mirror://hackage/" ++ display pkgId ++ ".tar.gz") tarballSHA256
                   & editedCabalFile .~ cabalSHA256
                   & metaSection.hydraPlatforms %~ (`Set.difference` Map.findWithDefault Set.empty name (dontDistributePackages config))
                   & metaSection.maintainers .~ Map.findWithDefault Set.empty name globalPackageMaintainers

--- a/src/Distribution/Nixpkgs/Fetch.hs
+++ b/src/Distribution/Nixpkgs/Fetch.hs
@@ -166,9 +166,9 @@ fetchWith (supportsRev, kind, addArgs) source = do
         case length ls of
           0 -> return Nothing
           1 -> return (Just (DerivationSource { derivKind = kind
-                                              , derivUrl = (sourceUrl source)
+                                              , derivUrl = sourceUrl source
                                               , derivRevision = ""
-                                              , derivHash = (BS.unpack (head ls))
+                                              , derivHash = BS.unpack (head ls)
                                               , derivSubmodule = Nothing
                                               }
                             , sourceUrl source))

--- a/src/Distribution/Nixpkgs/Haskell/Derivation.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Derivation.hs
@@ -112,7 +112,7 @@ instance Pretty Derivation where
     , nest 2 $ vcat
       [ attr "pname"   $ doubleQuotes $ disp (packageName _pkgid)
       , attr "version" $ doubleQuotes $ disp (packageVersion _pkgid)
-      , sourceAttr _src
+      , pPrint _src
       , onlyIf (_subpath /= ".") $ attr "postUnpack" postUnpack
       , onlyIf (_revision > 0) $ attr "revision" $ doubleQuotes $ int _revision
       , onlyIf (not (null _editedCabalFile) && _revision > 0) $ attr "editedCabalFile" $ string _editedCabalFile
@@ -148,17 +148,5 @@ instance Pretty Derivation where
       renderedFlags = [ text "-f" <> (if enable then empty else char '-') <> text (unFlagName f) | (f, enable) <- unFlagAssignment _cabalFlags ]
                       ++ map text (toAscList _configureFlags)
       isHackagePackage = "mirror://hackage/" `isPrefixOf` derivUrl _src
-      sourceAttr DerivationSource {..}
-        | isHackagePackage = attr "sha256" $ string derivHash
-        | derivKind /= "" = vcat
-           [ text "src" <+> equals <+> text ("fetch" ++ derivKind) <+> lbrace
-           , nest 2 $ vcat
-             [ attr "url" $ string derivUrl
-             , attr "sha256" $ string derivHash
-             , if derivRevision /= "" then attr "rev" (string derivRevision) else empty
-             ]
-           , rbrace <> semi
-           ]
-        | otherwise = attr "src" $ text derivUrl
 
       postUnpack = string $ "sourceRoot+=/" ++ _subpath ++ "; echo source root reset to $sourceRoot"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -57,6 +57,7 @@ testLibrary cabalFile = do
                                   , derivUrl      = "mirror://hackage/foo.tar.gz"
                                   , derivRevision = ""
                                   , derivHash     = "deadbeef"
+                                  , derivSubmodule = Nothing
                                   }
                        & extraFunctionArgs %~ Set.union (Set.singleton "inherit stdenv")
   goldenVsFileDiff


### PR DESCRIPTION
This was overlooked in my previous (accepted) patch which adds the `--dont-fetch-submodules` command-line flag: the generated nix specification for `src` should reflect the setting of that flag so that the corresponding `fetchgit` operation behaves similarly.  This has no effect for `src` directives that do not use `fetchgit`.