### PR TITLE
Add `isSimpleBuild` to generated derivations

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/Derivation.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Derivation.hs
@@ -9,7 +9,7 @@ module Distribution.Nixpkgs.Haskell.Derivation
   , extraFunctionArgs, libraryDepends, executableDepends, testDepends, configureFlags
   , cabalFlags, runHaddock, jailbreak, doCheck, testTarget, hyperlinkSource, enableSplitObjs
   , enableLibraryProfiling, enableExecutableProfiling, phaseOverrides, editedCabalFile, metaSection
-  , dependencies, setupDepends, benchmarkDepends, enableSeparateDataOutput
+  , dependencies, setupDepends, benchmarkDepends, enableSeparateDataOutput, isSimpleBuild
   )
   where
 
@@ -63,6 +63,7 @@ data Derivation = MkDerivation
   , _phaseOverrides             :: String
   , _editedCabalFile            :: String
   , _enableSeparateDataOutput   :: Bool
+  , _isSimpleBuild              :: Bool
   , _metaSection                :: Meta
   }
   deriving (Show, Eq, Generic)
@@ -94,6 +95,7 @@ nullDerivation = MkDerivation
   , _phaseOverrides = error "undefined Derivation.phaseOverrides"
   , _editedCabalFile = error "undefined Derivation.editedCabalFile"
   , _enableSeparateDataOutput = error "undefined Derivation.enableSeparateDataOutput"
+  , _isSimpleBuild = error "undefined Derivation.isSimpleBuild"
   , _metaSection = error "undefined Derivation.metaSection"
   }
 
@@ -116,6 +118,7 @@ instance Pretty Derivation where
       , onlyIf (_subpath /= ".") $ attr "postUnpack" postUnpack
       , onlyIf (_revision > 0) $ attr "revision" $ doubleQuotes $ int _revision
       , onlyIf (not (null _editedCabalFile) && _revision > 0) $ attr "editedCabalFile" $ string _editedCabalFile
+      , boolattr "isSimpleBuild" _isSimpleBuild _isSimpleBuild
       , listattr "configureFlags" empty (map (show . show) renderedFlags)
       , boolattr "isLibrary" (not _isLibrary || _isExecutable) _isLibrary
       , boolattr "isExecutable" (not _isLibrary || _isExecutable) _isExecutable

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -75,7 +75,7 @@ finalizeGenericPackageDescription haskellResolver arch compiler flags constraint
     Right (d,_)  -> (d,[])
 
 fromPackageDescription :: HaskellResolver -> NixpkgsResolver -> [Dependency] -> FlagAssignment -> PackageDescription -> Derivation
-fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags PackageDescription {..} = normalize $ postProcess $ nullDerivation
+fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags pd@PackageDescription {..} = normalize $ postProcess $ nullDerivation
     & isLibrary .~ isJust library
     & pkgid .~ package
     & revision .~ xrev
@@ -103,6 +103,7 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
     & editedCabalFile .~ (if xrev > 0
                              then fromMaybe (error (display package ++ ": X-Cabal-File-Hash field is missing")) (lookup "X-Cabal-File-Hash" customFieldsPD)
                              else "")
+    & isSimpleBuild .~ (Cabal.buildType pd == Cabal.Simple)
     & metaSection .~ ( Nix.nullMeta
                      & Nix.homepage .~ homepage
                      & Nix.description .~ synopsis

--- a/test/golden-test-cases/ChasingBottoms.nix.golden
+++ b/test/golden-test-cases/ChasingBottoms.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "ChasingBottoms";
   version = "1.3.1.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers mtl QuickCheck random syb
   ];

--- a/test/golden-test-cases/Clipboard.nix.golden
+++ b/test/golden-test-cases/Clipboard.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "Clipboard";
   version = "2.3.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base directory unix utf8-string X11 ];
   homepage = "http://haskell.org/haskellwiki/Clipboard";
   description = "System clipboard interface";

--- a/test/golden-test-cases/FenwickTree.nix.golden
+++ b/test/golden-test-cases/FenwickTree.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "FenwickTree";
   version = "0.1.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [ base QuickCheck template-haskell ];
   testHaskellDepends = [ base QuickCheck template-haskell ];

--- a/test/golden-test-cases/GPipe-GLFW.nix.golden
+++ b/test/golden-test-cases/GPipe-GLFW.nix.golden
@@ -4,6 +4,7 @@ mkDerivation {
   pname = "GPipe-GLFW";
   version = "1.4.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [ async base containers GLFW-b GPipe stm ];
   homepage = "https://github.com/plredmond/GPipe-GLFW";

--- a/test/golden-test-cases/GenericPretty.nix.golden
+++ b/test/golden-test-cases/GenericPretty.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "GenericPretty";
   version = "1.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ghc-prim pretty ];
   homepage = "https://github.com/RazvanRanca/GenericPretty";
   description = "A generic, derivable, haskell pretty printer";

--- a/test/golden-test-cases/HPDF.nix.golden
+++ b/test/golden-test-cases/HPDF.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "HPDF";
   version = "1.4.10";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base base64-bytestring binary bytestring containers errors
     mtl random vector zlib

--- a/test/golden-test-cases/HTF.nix.golden
+++ b/test/golden-test-cases/HTF.nix.golden
@@ -9,6 +9,7 @@ mkDerivation {
   pname = "HTF";
   version = "0.13.2.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/HTTP.nix.golden
+++ b/test/golden-test-cases/HTTP.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "HTTP";
   version = "4000.3.9";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base bytestring mtl network network-uri parsec time
   ];

--- a/test/golden-test-cases/Hclip.nix.golden
+++ b/test/golden-test-cases/Hclip.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "Hclip";
   version = "3.0.0.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base mtl process strict ];
   homepage = "https://github.com/jetho/Hclip";
   description = "A small cross-platform library for reading and modifying the system clipboard";

--- a/test/golden-test-cases/MissingH.nix.golden
+++ b/test/golden-test-cases/MissingH.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "MissingH";
   version = "1.4.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base containers directory filepath hslogger HUnit mtl network
     old-locale old-time parsec process random regex-compat time unix

--- a/test/golden-test-cases/ObjectName.nix.golden
+++ b/test/golden-test-cases/ObjectName.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "ObjectName";
   version = "1.1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base transformers ];
   homepage = "https://github.com/svenpanne/ObjectName";
   description = "Explicitly handled object names";

--- a/test/golden-test-cases/Only.nix.golden
+++ b/test/golden-test-cases/Only.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "Only";
   version = "0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base deepseq ];
   description = "The 1-tuple type or single-value \"collection\"";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/QuasiText.nix.golden
+++ b/test/golden-test-cases/QuasiText.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "QuasiText";
   version = "0.1.2.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base haskell-src-meta template-haskell text
     th-lift-instances

--- a/test/golden-test-cases/QuickCheck.nix.golden
+++ b/test/golden-test-cases/QuickCheck.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "QuickCheck";
   version = "2.10.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers deepseq random template-haskell tf-random
     transformers

--- a/test/golden-test-cases/ReadArgs.nix.golden
+++ b/test/golden-test-cases/ReadArgs.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "ReadArgs";
   version = "1.2.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base system-filepath text ];

--- a/test/golden-test-cases/SHA.nix.golden
+++ b/test/golden-test-cases/SHA.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "SHA";
   version = "1.6.4.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ array base binary bytestring ];

--- a/test/golden-test-cases/Strafunski-StrategyLib.nix.golden
+++ b/test/golden-test-cases/Strafunski-StrategyLib.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "Strafunski-StrategyLib";
   version = "5.0.0.10";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base directory mtl syb transformers ];
   description = "Library for strategic programming";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/accelerate-fftw.nix.golden
+++ b/test/golden-test-cases/accelerate-fftw.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "accelerate-fftw";
   version = "1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     accelerate accelerate-io base carray fft storable-complex
   ];

--- a/test/golden-test-cases/accelerate.nix.golden
+++ b/test/golden-test-cases/accelerate.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "accelerate";
   version = "1.1.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     ansi-wl-pprint base base-orphans containers deepseq directory
     exceptions fclabels filepath ghc-prim hashable hashtables mtl

--- a/test/golden-test-cases/active.nix.golden
+++ b/test/golden-test-cases/active.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "active";
   version = "0.2.0.13";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base lens linear semigroupoids semigroups vector
   ];

--- a/test/golden-test-cases/adjunctions.nix.golden
+++ b/test/golden-test-cases/adjunctions.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "adjunctions";
   version = "4.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base comonad containers contravariant distributive free mtl
     profunctors semigroupoids semigroups tagged transformers

--- a/test/golden-test-cases/aeson-diff.nix.golden
+++ b/test/golden-test-cases/aeson-diff.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "aeson-diff";
   version = "1.1.0.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/aeson-pretty.nix.golden
+++ b/test/golden-test-cases/aeson-pretty.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "aeson-pretty";
   version = "0.8.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/algebraic-graphs.nix.golden
+++ b/test/golden-test-cases/algebraic-graphs.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "algebraic-graphs";
   version = "0.0.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ array base containers ];
   testHaskellDepends = [ base containers extra QuickCheck ];
   benchmarkHaskellDepends = [ base containers criterion ];

--- a/test/golden-test-cases/amazonka-cloudtrail.nix.golden
+++ b/test/golden-test-cases/amazonka-cloudtrail.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-cloudtrail";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/amazonka-cloudwatch-logs.nix.golden
+++ b/test/golden-test-cases/amazonka-cloudwatch-logs.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-cloudwatch-logs";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/amazonka-codedeploy.nix.golden
+++ b/test/golden-test-cases/amazonka-codedeploy.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-codedeploy";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/amazonka-cognito-idp.nix.golden
+++ b/test/golden-test-cases/amazonka-cognito-idp.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-cognito-idp";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/amazonka-ecs.nix.golden
+++ b/test/golden-test-cases/amazonka-ecs.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-ecs";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/amazonka-kms.nix.golden
+++ b/test/golden-test-cases/amazonka-kms.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-kms";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/amazonka-lightsail.nix.golden
+++ b/test/golden-test-cases/amazonka-lightsail.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-lightsail";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/amazonka-route53-domains.nix.golden
+++ b/test/golden-test-cases/amazonka-route53-domains.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-route53-domains";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/amazonka-waf.nix.golden
+++ b/test/golden-test-cases/amazonka-waf.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "amazonka-waf";
   version = "1.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ amazonka-core base ];
   testHaskellDepends = [
     amazonka-core amazonka-test base bytestring tasty tasty-hunit text

--- a/test/golden-test-cases/api-field-json-th.nix.golden
+++ b/test/golden-test-cases/api-field-json-th.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "api-field-json-th";
   version = "0.1.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base lens split template-haskell text
   ];

--- a/test/golden-test-cases/app-settings.nix.golden
+++ b/test/golden-test-cases/app-settings.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "app-settings";
   version = "0.2.0.11";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers directory mtl parsec text
   ];

--- a/test/golden-test-cases/apply-refact.nix.golden
+++ b/test/golden-test-cases/apply-refact.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "apply-refact";
   version = "0.4.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/async.nix.golden
+++ b/test/golden-test-cases/async.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "async";
   version = "2.1.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base stm ];
   testHaskellDepends = [
     base HUnit test-framework test-framework-hunit

--- a/test/golden-test-cases/attoparsec-expr.nix.golden
+++ b/test/golden-test-cases/attoparsec-expr.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "attoparsec-expr";
   version = "0.1.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ attoparsec base ];
   description = "Port of parsec's expression parser to attoparsec";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/avers-server.nix.golden
+++ b/test/golden-test-cases/avers-server.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "avers-server";
   version = "0.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson avers avers-api base base64-bytestring bytestring
     bytestring-conversion containers cookie cryptonite http-types

--- a/test/golden-test-cases/aws.nix.golden
+++ b/test/golden-test-cases/aws.nix.golden
@@ -13,6 +13,7 @@ mkDerivation {
   pname = "aws";
   version = "0.18";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/bbdb.nix.golden
+++ b/test/golden-test-cases/bbdb.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "bbdb";
   version = "0.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base parsec ];
   testHaskellDepends = [ base hspec parsec ];
   homepage = "https://github.com/henrylaxen/bbdb";

--- a/test/golden-test-cases/benchpress.nix.golden
+++ b/test/golden-test-cases/benchpress.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "benchpress";
   version = "0.2.2.10";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base mtl time ];

--- a/test/golden-test-cases/binary-bits.nix.golden
+++ b/test/golden-test-cases/binary-bits.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "binary-bits";
   version = "0.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base binary bytestring ];
   testHaskellDepends = [
     base binary bytestring QuickCheck random test-framework

--- a/test/golden-test-cases/binary-tagged.nix.golden
+++ b/test/golden-test-cases/binary-tagged.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "binary-tagged";
   version = "0.1.4.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson array base base16-bytestring binary bytestring containers
     generics-sop hashable nats scientific semigroups SHA tagged text

--- a/test/golden-test-cases/bindings-uname.nix.golden
+++ b/test/golden-test-cases/bindings-uname.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "bindings-uname";
   version = "0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   description = "Low-level binding to POSIX uname(3)";
   license = stdenv.lib.licenses.publicDomain;

--- a/test/golden-test-cases/bioalign.nix.golden
+++ b/test/golden-test-cases/bioalign.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "bioalign";
   version = "0.0.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base biocore bytestring ];
   homepage = "https://patch-tag.com/r/dfornika/biophd/home";
   description = "Data structures and helper functions for calculating alignments";

--- a/test/golden-test-cases/blank-canvas.nix.golden
+++ b/test/golden-test-cases/blank-canvas.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "blank-canvas";
   version = "0.6.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     aeson base base-compat base64-bytestring bytestring colour

--- a/test/golden-test-cases/blaze-html.nix.golden
+++ b/test/golden-test-cases/blaze-html.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "blaze-html";
   version = "0.9.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base blaze-builder blaze-markup bytestring text
   ];

--- a/test/golden-test-cases/blaze-markup.nix.golden
+++ b/test/golden-test-cases/blaze-markup.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "blaze-markup";
   version = "0.8.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base blaze-builder bytestring text ];
   testHaskellDepends = [
     base blaze-builder bytestring containers HUnit QuickCheck

--- a/test/golden-test-cases/blaze-svg.nix.golden
+++ b/test/golden-test-cases/blaze-svg.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "blaze-svg";
   version = "0.3.6.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base blaze-markup mtl ];
   homepage = "https://github.com/deepakjois/blaze-svg";
   description = "SVG combinator library";

--- a/test/golden-test-cases/blosum.nix.golden
+++ b/test/golden-test-cases/blosum.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "blosum";
   version = "0.1.1.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/boomerang.nix.golden
+++ b/test/golden-test-cases/boomerang.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "boomerang";
   version = "1.4.5.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base mtl template-haskell text ];
   description = "Library for invertible parsing and printing";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/boxes.nix.golden
+++ b/test/golden-test-cases/boxes.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "boxes";
   version = "0.1.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base split ];
   testHaskellDepends = [ base QuickCheck split ];
   description = "2D text pretty-printing library";

--- a/test/golden-test-cases/brittany.nix.golden
+++ b/test/golden-test-cases/brittany.nix.golden
@@ -9,6 +9,7 @@ mkDerivation {
   pname = "brittany";
   version = "0.9.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/broadcast-chan.nix.golden
+++ b/test/golden-test-cases/broadcast-chan.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "broadcast-chan";
   version = "0.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "https://github.com/merijn/broadcast-chan";
   description = "Broadcast channel type that avoids 0 reader space leaks";

--- a/test/golden-test-cases/butcher.nix.golden
+++ b/test/golden-test-cases/butcher.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "butcher";
   version = "1.2.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bifunctors containers deque either extra free microlens
     microlens-th mtl multistate pretty transformers unsafe void

--- a/test/golden-test-cases/bzlib.nix.golden
+++ b/test/golden-test-cases/bzlib.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "bzlib";
   version = "0.5.0.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring ];
   librarySystemDepends = [ bzip2 ];
   description = "Compression and decompression in the bzip2 format";

--- a/test/golden-test-cases/case-insensitive.nix.golden
+++ b/test/golden-test-cases/case-insensitive.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "case-insensitive";
   version = "1.2.0.10";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring deepseq hashable text ];
   testHaskellDepends = [
     base bytestring HUnit test-framework test-framework-hunit text

--- a/test/golden-test-cases/cassava-conduit.nix.golden
+++ b/test/golden-test-cases/cassava-conduit.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "cassava-conduit";
   version = "0.4.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base bifunctors bytestring cassava conduit conduit-extra
     containers mtl text

--- a/test/golden-test-cases/cassette.nix.golden
+++ b/test/golden-test-cases/cassette.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "cassette";
   version = "0.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   description = "A combinator library for simultaneously defining parsers and pretty printers";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/cereal-text.nix.golden
+++ b/test/golden-test-cases/cereal-text.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "cereal-text";
   version = "0.1.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base cereal text ];
   homepage = "https://github.com/ulikoehler/cereal-text";
   description = "Data.Text instances for the cereal serialization library";

--- a/test/golden-test-cases/cheapskate.nix.golden
+++ b/test/golden-test-cases/cheapskate.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "cheapskate";
   version = "0.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/chell.nix.golden
+++ b/test/golden-test-cases/chell.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "chell";
   version = "0.4.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     ansi-terminal base bytestring options patience random
     template-haskell text transformers

--- a/test/golden-test-cases/clumpiness.nix.golden
+++ b/test/golden-test-cases/clumpiness.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "clumpiness";
   version = "0.17.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers tree-fun ];
   description = "Calculate the clumpiness of leaf properties in a tree";
   license = stdenv.lib.licenses.gpl3;

--- a/test/golden-test-cases/code-page.nix.golden
+++ b/test/golden-test-cases/code-page.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "code-page";
   version = "0.1.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [ base ];
   homepage = "https://github.com/RyanGlScott/code-page";

--- a/test/golden-test-cases/colorize-haskell.nix.golden
+++ b/test/golden-test-cases/colorize-haskell.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "colorize-haskell";
   version = "1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ ansi-terminal base haskell-lexer ];

--- a/test/golden-test-cases/countable.nix.golden
+++ b/test/golden-test-cases/countable.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "countable";
   version = "1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [
     base bytestring silently tasty tasty-golden tasty-hunit

--- a/test/golden-test-cases/cpu.nix.golden
+++ b/test/golden-test-cases/cpu.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "cpu";
   version = "0.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/criterion.nix.golden
+++ b/test/golden-test-cases/criterion.nix.golden
@@ -10,6 +10,7 @@ mkDerivation {
   pname = "criterion";
   version = "1.2.6.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/crypt-sha512.nix.golden
+++ b/test/golden-test-cases/crypt-sha512.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "crypt-sha512";
   version = "0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base bytestring cryptohash-sha512
   ];

--- a/test/golden-test-cases/crypto-random-api.nix.golden
+++ b/test/golden-test-cases/crypto-random-api.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "crypto-random-api";
   version = "0.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring entropy ];
   homepage = "http://github.com/vincenthz/hs-crypto-random-api";
   description = "Simple random generators API for cryptography related code";

--- a/test/golden-test-cases/csv.nix.golden
+++ b/test/golden-test-cases/csv.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "csv";
   version = "0.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base filepath parsec ];
   description = "CSV loader and dumper";
   license = stdenv.lib.licenses.mit;

--- a/test/golden-test-cases/data-accessor.nix.golden
+++ b/test/golden-test-cases/data-accessor.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "data-accessor";
   version = "0.2.2.7";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ array base containers transformers ];
   homepage = "http://www.haskell.org/haskellwiki/Record_access";
   description = "Utilities for accessing and manipulating fields of records";

--- a/test/golden-test-cases/data-default-instances-containers.nix.golden
+++ b/test/golden-test-cases/data-default-instances-containers.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "data-default-instances-containers";
   version = "0.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers data-default-class ];
   description = "Default instances for types in containers";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/data-endian.nix.golden
+++ b/test/golden-test-cases/data-endian.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "data-endian";
   version = "0.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "https://github.com/mvv/data-endian";
   description = "Endian-sensitive data";

--- a/test/golden-test-cases/data-msgpack.nix.golden
+++ b/test/golden-test-cases/data-msgpack.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "data-msgpack";
   version = "0.0.10";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/data-serializer.nix.golden
+++ b/test/golden-test-cases/data-serializer.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "data-serializer";
   version = "0.3.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base binary bytestring cereal data-endian parsers semigroups split
   ];

--- a/test/golden-test-cases/deque.nix.golden
+++ b/test/golden-test-cases/deque.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "deque";
   version = "0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "https://github.com/nikita-volkov/deque";
   description = "Double-ended queue";

--- a/test/golden-test-cases/dhall-bash.nix.golden
+++ b/test/golden-test-cases/dhall-bash.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "dhall-bash";
   version = "1.0.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/diagrams-solve.nix.golden
+++ b/test/golden-test-cases/diagrams-solve.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "diagrams-solve";
   version = "0.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [
     base deepseq tasty tasty-hunit tasty-quickcheck

--- a/test/golden-test-cases/discrimination.nix.golden
+++ b/test/golden-test-cases/discrimination.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "discrimination";
   version = "0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base containers contravariant deepseq ghc-prim hashable
     primitive profunctors promises semigroups transformers

--- a/test/golden-test-cases/dotenv.nix.golden
+++ b/test/golden-test-cases/dotenv.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "dotenv";
   version = "0.5.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/dotnet-timespan.nix.golden
+++ b/test/golden-test-cases/dotnet-timespan.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "dotnet-timespan";
   version = "0.0.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "http://github.com/YoEight/dotnet-timespan";
   description = ".NET TimeSpan";

--- a/test/golden-test-cases/dpor.nix.golden
+++ b/test/golden-test-cases/dpor.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "dpor";
   version = "0.2.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers deepseq random semigroups
   ];

--- a/test/golden-test-cases/drawille.nix.golden
+++ b/test/golden-test-cases/drawille.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "drawille";
   version = "0.1.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base containers ];

--- a/test/golden-test-cases/drifter-postgresql.nix.golden
+++ b/test/golden-test-cases/drifter-postgresql.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "drifter-postgresql";
   version = "0.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers drifter mtl postgresql-simple time transformers
     transformers-compat

--- a/test/golden-test-cases/ede.nix.golden
+++ b/test/golden-test-cases/ede.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "ede";
   version = "0.2.8.7";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     aeson ansi-wl-pprint base bifunctors bytestring comonad directory

--- a/test/golden-test-cases/ekg-cloudwatch.nix.golden
+++ b/test/golden-test-cases/ekg-cloudwatch.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "ekg-cloudwatch";
   version = "0.0.1.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     amazonka amazonka-cloudwatch amazonka-core base bytestring ekg-core
     lens resourcet semigroups text time unordered-containers

--- a/test/golden-test-cases/emailaddress.nix.golden
+++ b/test/golden-test-cases/emailaddress.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "emailaddress";
   version = "0.2.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bifunctors bytestring email-validate http-api-data
     opaleye path-pieces persistent postgresql-simple

--- a/test/golden-test-cases/envelope.nix.golden
+++ b/test/golden-test-cases/envelope.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "envelope";
   version = "0.2.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ aeson base http-api-data mtl text ];
   testHaskellDepends = [ base doctest Glob ];
   homepage = "https://github.com/cdepillabout/envelope#readme";

--- a/test/golden-test-cases/eventful-sqlite.nix.golden
+++ b/test/golden-test-cases/eventful-sqlite.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "eventful-sqlite";
   version = "0.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bytestring eventful-core eventful-sql-common mtl
     persistent text uuid

--- a/test/golden-test-cases/exact-pi.nix.golden
+++ b/test/golden-test-cases/exact-pi.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "exact-pi";
   version = "0.4.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base numtype-dk ];
   homepage = "https://github.com/dmcclean/exact-pi/";
   description = "Exact rational multiples of pi (and integer powers of pi)";

--- a/test/golden-test-cases/expiring-cache-map.nix.golden
+++ b/test/golden-test-cases/expiring-cache-map.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "expiring-cache-map";
   version = "0.0.6.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers hashable unordered-containers
   ];

--- a/test/golden-test-cases/explicit-exception.nix.golden
+++ b/test/golden-test-cases/explicit-exception.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "explicit-exception";
   version = "0.1.9";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base deepseq transformers ];

--- a/test/golden-test-cases/fdo-notify.nix.golden
+++ b/test/golden-test-cases/fdo-notify.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "fdo-notify";
   version = "0.3.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers dbus ];
   homepage = "http://bitbucket.org/taejo/fdo-notify/";
   description = "Desktop Notifications client";

--- a/test/golden-test-cases/fgl.nix.golden
+++ b/test/golden-test-cases/fgl.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "fgl";
   version = "5.5.4.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base containers deepseq transformers
   ];

--- a/test/golden-test-cases/file-modules.nix.golden
+++ b/test/golden-test-cases/file-modules.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "file-modules";
   version = "0.1.2.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/fingertree.nix.golden
+++ b/test/golden-test-cases/fingertree.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "fingertree";
   version = "0.1.3.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [
     base HUnit QuickCheck test-framework test-framework-hunit

--- a/test/golden-test-cases/fixed-vector.nix.golden
+++ b/test/golden-test-cases/fixed-vector.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "fixed-vector";
   version = "1.0.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base deepseq primitive ];
   testHaskellDepends = [ base doctest filemanip primitive ];
   description = "Generic vectors with statically known size";

--- a/test/golden-test-cases/fixed.nix.golden
+++ b/test/golden-test-cases/fixed.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "fixed";
   version = "0.2.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "http://github.com/ekmett/fixed";
   description = "Signed 15.16 precision fixed point arithmetic";

--- a/test/golden-test-cases/foundation.nix.golden
+++ b/test/golden-test-cases/foundation.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "foundation";
   version = "0.0.17";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base basement ghc-prim ];
   testHaskellDepends = [ base basement ];
   benchmarkHaskellDepends = [ base basement gauge ];

--- a/test/golden-test-cases/frisby.nix.golden
+++ b/test/golden-test-cases/frisby.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "frisby";
   version = "0.2.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ array base containers mtl semigroups ];
   homepage = "http://repetae.net/computer/frisby/";
   description = "Linear time composable parser for PEG grammars";

--- a/test/golden-test-cases/funcmp.nix.golden
+++ b/test/golden-test-cases/funcmp.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "funcmp";
   version = "1.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [ base filepath process ];
   homepage = "http://savannah.nongnu.org/projects/funcmp/";

--- a/test/golden-test-cases/functor-classes-compat.nix.golden
+++ b/test/golden-test-cases/functor-classes-compat.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "functor-classes-compat";
   version = "1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers hashable unordered-containers vector
   ];

--- a/test/golden-test-cases/general-games.nix.golden
+++ b/test/golden-test-cases/general-games.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "general-games";
   version = "1.0.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base monad-loops MonadRandom random random-shuffle
   ];

--- a/test/golden-test-cases/generic-lens.nix.golden
+++ b/test/golden-test-cases/generic-lens.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "generic-lens";
   version = "0.5.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base profunctors tagged ];
   testHaskellDepends = [ base doctest inspection-testing lens ];
   benchmarkHaskellDepends = [

--- a/test/golden-test-cases/genvalidity-aeson.nix.golden
+++ b/test/golden-test-cases/genvalidity-aeson.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "genvalidity-aeson";
   version = "0.1.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base genvalidity genvalidity-scientific genvalidity-text
     genvalidity-unordered-containers genvalidity-vector QuickCheck

--- a/test/golden-test-cases/genvalidity-hspec-aeson.nix.golden
+++ b/test/golden-test-cases/genvalidity-hspec-aeson.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "genvalidity-hspec-aeson";
   version = "0.1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bytestring deepseq genvalidity genvalidity-hspec hspec
     QuickCheck

--- a/test/golden-test-cases/genvalidity-hspec-binary.nix.golden
+++ b/test/golden-test-cases/genvalidity-hspec-binary.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "genvalidity-hspec-binary";
   version = "0.1.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base binary deepseq genvalidity genvalidity-hspec hspec QuickCheck
   ];

--- a/test/golden-test-cases/genvalidity-scientific.nix.golden
+++ b/test/golden-test-cases/genvalidity-scientific.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "genvalidity-scientific";
   version = "0.1.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base genvalidity QuickCheck scientific validity validity-scientific
   ];

--- a/test/golden-test-cases/genvalidity-uuid.nix.golden
+++ b/test/golden-test-cases/genvalidity-uuid.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "genvalidity-uuid";
   version = "0.0.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base genvalidity QuickCheck uuid validity validity-uuid
   ];

--- a/test/golden-test-cases/ghc-syb-utils.nix.golden
+++ b/test/golden-test-cases/ghc-syb-utils.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "ghc-syb-utils";
   version = "0.2.3.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ghc syb ];
   testHaskellDepends = [ base directory filepath ghc ghc-paths ];
   homepage = "http://github.com/nominolo/ghc-syb";

--- a/test/golden-test-cases/ghcid.nix.golden
+++ b/test/golden-test-cases/ghcid.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "ghcid";
   version = "0.6.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/giphy-api.nix.golden
+++ b/test/golden-test-cases/giphy-api.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "giphy-api";
   version = "0.5.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/github.nix.golden
+++ b/test/golden-test-cases/github.nix.golden
@@ -11,6 +11,7 @@ mkDerivation {
   pname = "github";
   version = "0.18";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson aeson-compat base base-compat base16-bytestring binary
     binary-orphans byteable bytestring containers cryptohash deepseq

--- a/test/golden-test-cases/gogol-adexchange-buyer.nix.golden
+++ b/test/golden-test-cases/gogol-adexchange-buyer.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-adexchange-buyer";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Ad Exchange Buyer SDK";

--- a/test/golden-test-cases/gogol-admin-emailmigration.nix.golden
+++ b/test/golden-test-cases/gogol-admin-emailmigration.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-admin-emailmigration";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Email Migration API v2 SDK";

--- a/test/golden-test-cases/gogol-affiliates.nix.golden
+++ b/test/golden-test-cases/gogol-affiliates.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-affiliates";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Affiliate Network SDK";

--- a/test/golden-test-cases/gogol-apps-tasks.nix.golden
+++ b/test/golden-test-cases/gogol-apps-tasks.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-apps-tasks";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Tasks SDK";

--- a/test/golden-test-cases/gogol-appstate.nix.golden
+++ b/test/golden-test-cases/gogol-appstate.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-appstate";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google App State SDK";

--- a/test/golden-test-cases/gogol-blogger.nix.golden
+++ b/test/golden-test-cases/gogol-blogger.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-blogger";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Blogger SDK";

--- a/test/golden-test-cases/gogol-datastore.nix.golden
+++ b/test/golden-test-cases/gogol-datastore.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-datastore";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Cloud Datastore SDK";

--- a/test/golden-test-cases/gogol-dfareporting.nix.golden
+++ b/test/golden-test-cases/gogol-dfareporting.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-dfareporting";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google DCM/DFA Reporting And Trafficking SDK";

--- a/test/golden-test-cases/gogol-firebase-rules.nix.golden
+++ b/test/golden-test-cases/gogol-firebase-rules.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-firebase-rules";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Firebase Rules SDK";

--- a/test/golden-test-cases/gogol-gmail.nix.golden
+++ b/test/golden-test-cases/gogol-gmail.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-gmail";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Gmail SDK";

--- a/test/golden-test-cases/gogol-kgsearch.nix.golden
+++ b/test/golden-test-cases/gogol-kgsearch.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-kgsearch";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Knowledge Graph Search SDK";

--- a/test/golden-test-cases/gogol-maps-engine.nix.golden
+++ b/test/golden-test-cases/gogol-maps-engine.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-maps-engine";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Maps Engine SDK";

--- a/test/golden-test-cases/gogol-plus.nix.golden
+++ b/test/golden-test-cases/gogol-plus.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-plus";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google + SDK";

--- a/test/golden-test-cases/gogol-resourceviews.nix.golden
+++ b/test/golden-test-cases/gogol-resourceviews.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-resourceviews";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Compute Engine Instance Groups SDK";

--- a/test/golden-test-cases/gogol-translate.nix.golden
+++ b/test/golden-test-cases/gogol-translate.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-translate";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Translate SDK";

--- a/test/golden-test-cases/gogol-webmaster-tools.nix.golden
+++ b/test/golden-test-cases/gogol-webmaster-tools.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-webmaster-tools";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Search Console SDK";

--- a/test/golden-test-cases/gogol-youtube.nix.golden
+++ b/test/golden-test-cases/gogol-youtube.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gogol-youtube";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google YouTube Data SDK";

--- a/test/golden-test-cases/groundhog-mysql.nix.golden
+++ b/test/golden-test-cases/groundhog-mysql.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "groundhog-mysql";
   version = "0.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring containers groundhog monad-control monad-logger
     mysql mysql-simple resource-pool resourcet text time transformers

--- a/test/golden-test-cases/gsasl.nix.golden
+++ b/test/golden-test-cases/gsasl.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "gsasl";
   version = "0.3.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring transformers ];
   libraryPkgconfigDepends = [ gsasl ];
   homepage = "https://john-millikin.com/software/haskell-gsasl/";

--- a/test/golden-test-cases/hOpenPGP.nix.golden
+++ b/test/golden-test-cases/hOpenPGP.nix.golden
@@ -13,6 +13,7 @@ mkDerivation {
   pname = "hOpenPGP";
   version = "2.5.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson attoparsec base base16-bytestring base64-bytestring
     bifunctors binary binary-conduit byteable bytestring bzlib conduit

--- a/test/golden-test-cases/hPDB-examples.nix.golden
+++ b/test/golden-test-cases/hPDB-examples.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "hPDB-examples";
   version = "1.2.0.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [

--- a/test/golden-test-cases/haddock-library.nix.golden
+++ b/test/golden-test-cases/haddock-library.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "haddock-library";
   version = "1.4.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring deepseq transformers ];
   testHaskellDepends = [
     base base-compat bytestring deepseq hspec QuickCheck transformers

--- a/test/golden-test-cases/hakyll.nix.golden
+++ b/test/golden-test-cases/hakyll.nix.golden
@@ -12,6 +12,7 @@ mkDerivation {
   pname = "hakyll";
   version = "4.10.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/happstack-hsp.nix.golden
+++ b/test/golden-test-cases/happstack-hsp.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "happstack-hsp";
   version = "7.3.7.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring happstack-server harp hsp hsx2hs mtl syb text
     utf8-string

--- a/test/golden-test-cases/harp.nix.golden
+++ b/test/golden-test-cases/harp.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "harp";
   version = "0.4.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "https://github.com/seereason/harp";
   description = "HaRP allows pattern-matching with regular expressions";

--- a/test/golden-test-cases/hashtables.nix.golden
+++ b/test/golden-test-cases/hashtables.nix.golden
@@ -4,6 +4,7 @@ mkDerivation {
   pname = "hashtables";
   version = "1.2.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base ghc-prim hashable primitive vector
   ];

--- a/test/golden-test-cases/haskell-tools-debug.nix.golden
+++ b/test/golden-test-cases/haskell-tools-debug.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "haskell-tools-debug";
   version = "1.0.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/haskell-tools-rewrite.nix.golden
+++ b/test/golden-test-cases/haskell-tools-rewrite.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "haskell-tools-rewrite";
   version = "1.0.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers ghc haskell-tools-ast haskell-tools-prettyprint mtl
     references

--- a/test/golden-test-cases/hasql.nix.golden
+++ b/test/golden-test-cases/hasql.nix.golden
@@ -10,6 +10,7 @@ mkDerivation {
   pname = "hasql";
   version = "1.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base base-prelude bytestring bytestring-strict-builder
     contravariant contravariant-extras data-default-class dlist

--- a/test/golden-test-cases/hformat.nix.golden
+++ b/test/golden-test-cases/hformat.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "hformat";
   version = "0.3.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     ansi-terminal base base-unicode-symbols text
   ];

--- a/test/golden-test-cases/highlighting-kate.nix.golden
+++ b/test/golden-test-cases/highlighting-kate.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "highlighting-kate";
   version = "0.6.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   configureFlags = [ "-fpcre-light" ];
   isLibrary = true;
   isExecutable = true;

--- a/test/golden-test-cases/hit.nix.golden
+++ b/test/golden-test-cases/hit.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "hit";
   version = "0.6.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/hjson.nix.golden
+++ b/test/golden-test-cases/hjson.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "hjson";
   version = "1.3.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers parsec ];
   description = "JSON parsing library";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/hmpfr.nix.golden
+++ b/test/golden-test-cases/hmpfr.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "hmpfr";
   version = "0.4.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [ base integer-gmp ];
   librarySystemDepends = [ mpfr ];

--- a/test/golden-test-cases/hoogle.nix.golden
+++ b/test/golden-test-cases/hoogle.nix.golden
@@ -10,6 +10,7 @@ mkDerivation {
   pname = "hoogle";
   version = "5.0.14";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/hostname-validate.nix.golden
+++ b/test/golden-test-cases/hostname-validate.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "hostname-validate";
   version = "1.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ attoparsec base bytestring ];
   description = "Validate hostnames e.g. localhost or foo.co.uk.";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/hsinstall.nix.golden
+++ b/test/golden-test-cases/hsinstall.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "hsinstall";
   version = "1.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/hstatsd.nix.golden
+++ b/test/golden-test-cases/hstatsd.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "hstatsd";
   version = "0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring mtl network text ];
   homepage = "https://github.com/mokus0/hstatsd";
   description = "Quick and dirty statsd interface";

--- a/test/golden-test-cases/hsx-jmacro.nix.golden
+++ b/test/golden-test-cases/hsx-jmacro.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "hsx-jmacro";
   version = "7.3.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base hsp jmacro mtl text wl-pprint-text
   ];

--- a/test/golden-test-cases/htoml.nix.golden
+++ b/test/golden-test-cases/htoml.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "htoml";
   version = "1.0.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base containers old-locale parsec text time
     unordered-containers vector

--- a/test/golden-test-cases/http-conduit.nix.golden
+++ b/test/golden-test-cases/http-conduit.nix.golden
@@ -10,6 +10,7 @@ mkDerivation {
   pname = "http-conduit";
   version = "2.2.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bytestring conduit conduit-extra exceptions http-client
     http-client-tls http-types lifted-base monad-control mtl resourcet

--- a/test/golden-test-cases/http-link-header.nix.golden
+++ b/test/golden-test-cases/http-link-header.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "http-link-header";
   version = "1.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base bytestring bytestring-conversion errors
     http-api-data network-uri text

--- a/test/golden-test-cases/http-media.nix.golden
+++ b/test/golden-test-cases/http-media.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "http-media";
   version = "0.7.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring case-insensitive containers utf8-string
   ];

--- a/test/golden-test-cases/hxt-charproperties.nix.golden
+++ b/test/golden-test-cases/hxt-charproperties.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "hxt-charproperties";
   version = "9.2.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "https://github.com/UweSchmidt/hxt";
   description = "Character properties and classes for XML and Unicode";

--- a/test/golden-test-cases/hxt-expat.nix.golden
+++ b/test/golden-test-cases/hxt-expat.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "hxt-expat";
   version = "9.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring hexpat hxt ];
   homepage = "http://www.fh-wedel.de/~si/HXmlToolbox/index.html";
   description = "Expat parser for HXT";

--- a/test/golden-test-cases/hxt-tagsoup.nix.golden
+++ b/test/golden-test-cases/hxt-tagsoup.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "hxt-tagsoup";
   version = "9.1.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base hxt hxt-charproperties hxt-unicode tagsoup
   ];

--- a/test/golden-test-cases/iconv.nix.golden
+++ b/test/golden-test-cases/iconv.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "iconv";
   version = "0.4.1.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring ];
   description = "String encoding conversion";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/incremental-parser.nix.golden
+++ b/test/golden-test-cases/incremental-parser.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "incremental-parser";
   version = "0.2.5.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base monoid-subclasses ];
   testHaskellDepends = [
     base checkers monoid-subclasses QuickCheck tasty tasty-quickcheck

--- a/test/golden-test-cases/indentation-core.nix.golden
+++ b/test/golden-test-cases/indentation-core.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "indentation-core";
   version = "0.0.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base mtl ];
   homepage = "https://bitbucket.org/adamsmd/indentation";
   description = "Indentation sensitive parsing combinators core library";

--- a/test/golden-test-cases/indentation-parsec.nix.golden
+++ b/test/golden-test-cases/indentation-parsec.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "indentation-parsec";
   version = "0.0.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base indentation-core mtl parsec ];
   testHaskellDepends = [ base parsec tasty tasty-hunit ];
   homepage = "https://bitbucket.org/adamsmd/indentation";

--- a/test/golden-test-cases/inline-c-cpp.nix.golden
+++ b/test/golden-test-cases/inline-c-cpp.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "inline-c-cpp";
   version = "0.2.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base inline-c safe-exceptions template-haskell
   ];

--- a/test/golden-test-cases/integer-logarithms.nix.golden
+++ b/test/golden-test-cases/integer-logarithms.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "integer-logarithms";
   version = "1.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ array base ghc-prim integer-gmp ];
   testHaskellDepends = [
     base QuickCheck smallcheck tasty tasty-hunit tasty-quickcheck

--- a/test/golden-test-cases/intero.nix.golden
+++ b/test/golden-test-cases/intero.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "intero";
   version = "0.1.24";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = false;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/invariant.nix.golden
+++ b/test/golden-test-cases/invariant.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "invariant";
   version = "0.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base bifunctors comonad containers contravariant ghc-prim
     profunctors semigroups StateVar stm tagged template-haskell

--- a/test/golden-test-cases/io-machine.nix.golden
+++ b/test/golden-test-cases/io-machine.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "io-machine";
   version = "0.2.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base time ];
   testHaskellDepends = [ base ];
   homepage = "https://github.com/YoshikuniJujo/io-machine#readme";

--- a/test/golden-test-cases/io-streams-haproxy.nix.golden
+++ b/test/golden-test-cases/io-streams-haproxy.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "io-streams-haproxy";
   version = "1.0.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base bytestring io-streams network transformers
   ];

--- a/test/golden-test-cases/ip.nix.golden
+++ b/test/golden-test-cases/ip.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "ip";
   version = "1.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson attoparsec base bytestring hashable primitive text vector
   ];

--- a/test/golden-test-cases/iso639.nix.golden
+++ b/test/golden-test-cases/iso639.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "iso639";
   version = "0.1.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "https://github.com/HugoDaniel/iso639";
   description = "ISO-639-1 language codes";

--- a/test/golden-test-cases/iso8601-time.nix.golden
+++ b/test/golden-test-cases/iso8601-time.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "iso8601-time";
   version = "0.1.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base time ];
   testHaskellDepends = [ base hspec HUnit time ];
   homepage = "https://github.com/nh2/iso8601-time";

--- a/test/golden-test-cases/jmacro-rpc-happstack.nix.golden
+++ b/test/golden-test-cases/jmacro-rpc-happstack.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "jmacro-rpc-happstack";
   version = "0.3.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base blaze-html bytestring containers happstack-server jmacro
     jmacro-rpc mtl

--- a/test/golden-test-cases/jmacro-rpc.nix.golden
+++ b/test/golden-test-cases/jmacro-rpc.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "jmacro-rpc";
   version = "0.3.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson attoparsec base blaze-html bytestring containers
     contravariant jmacro mtl scientific split text unordered-containers

--- a/test/golden-test-cases/jose.nix.golden
+++ b/test/golden-test-cases/jose.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "jose";
   version = "0.6.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/katip-elasticsearch.nix.golden
+++ b/test/golden-test-cases/katip-elasticsearch.nix.golden
@@ -9,6 +9,7 @@ mkDerivation {
   pname = "katip-elasticsearch";
   version = "0.4.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson async base bloodhound bytestring enclosed-exceptions
     exceptions http-client http-types katip retry scientific stm

--- a/test/golden-test-cases/katip.nix.golden
+++ b/test/golden-test-cases/katip.nix.golden
@@ -12,6 +12,7 @@ mkDerivation {
   pname = "katip";
   version = "0.5.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson async auto-update base bytestring containers either hostname
     microlens microlens-th monad-control mtl old-locale resourcet

--- a/test/golden-test-cases/katydid.nix.golden
+++ b/test/golden-test-cases/katydid.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "katydid";
   version = "0.1.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/kawhi.nix.golden
+++ b/test/golden-test-cases/kawhi.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "kawhi";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bytestring exceptions http-client http-conduit
     http-types mtl safe scientific text

--- a/test/golden-test-cases/kraken.nix.golden
+++ b/test/golden-test-cases/kraken.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "kraken";
   version = "0.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bytestring http-client http-client-tls mtl
   ];

--- a/test/golden-test-cases/l10n.nix.golden
+++ b/test/golden-test-cases/l10n.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "l10n";
   version = "0.1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base text time ];
   homepage = "https://github.com/louispan/l10n#readme";
   description = "Enables providing localization as typeclass instances in separate files";

--- a/test/golden-test-cases/lambdabot-social-plugins.nix.golden
+++ b/test/golden-test-cases/lambdabot-social-plugins.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "lambdabot-social-plugins";
   version = "5.1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base binary bytestring containers lambdabot-core mtl split time
   ];

--- a/test/golden-test-cases/lazy-csv.nix.golden
+++ b/test/golden-test-cases/lazy-csv.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "lazy-csv";
   version = "0.5.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base bytestring ];

--- a/test/golden-test-cases/libgit.nix.golden
+++ b/test/golden-test-cases/libgit.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "libgit";
   version = "0.3.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base mtl process ];
   homepage = "https://github.com/vincenthz/hs-libgit";
   description = "Simple Git Wrapper";

--- a/test/golden-test-cases/librato.nix.golden
+++ b/test/golden-test-cases/librato.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "librato";
   version = "0.2.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson attoparsec base bytestring either http-client http-conduit
     http-types mtl resourcet text unordered-containers uri-templater

--- a/test/golden-test-cases/lifted-async.nix.golden
+++ b/test/golden-test-cases/lifted-async.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "lifted-async";
   version = "0.9.3.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     async base constraints lifted-base monad-control transformers-base
   ];

--- a/test/golden-test-cases/lmdb.nix.golden
+++ b/test/golden-test-cases/lmdb.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "lmdb";
   version = "0.2.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ array base ];
   librarySystemDepends = [ lmdb ];
   homepage = "http://github.com/dmbarbour/haskell-lmdb";

--- a/test/golden-test-cases/logging-effect-extra-file.nix.golden
+++ b/test/golden-test-cases/logging-effect-extra-file.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "logging-effect-extra-file";
   version = "1.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/lucid.nix.golden
+++ b/test/golden-test-cases/lucid.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "lucid";
   version = "2.9.9";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base blaze-builder bytestring containers hashable mmorph mtl text
     transformers unordered-containers

--- a/test/golden-test-cases/mainland-pretty.nix.golden
+++ b/test/golden-test-cases/mainland-pretty.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "mainland-pretty";
   version = "0.6.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers srcloc text transformers
   ];

--- a/test/golden-test-cases/matrices.nix.golden
+++ b/test/golden-test-cases/matrices.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "matrices";
   version = "0.4.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base deepseq primitive vector ];
   testHaskellDepends = [
     base tasty tasty-hunit tasty-quickcheck vector

--- a/test/golden-test-cases/median-stream.nix.golden
+++ b/test/golden-test-cases/median-stream.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "median-stream";
   version = "0.7.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base heap ];
   testHaskellDepends = [ base QuickCheck ];
   homepage = "https://github.com/caneroj1/median-stream#readme";

--- a/test/golden-test-cases/megaparsec.nix.golden
+++ b/test/golden-test-cases/megaparsec.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "megaparsec";
   version = "6.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring case-insensitive containers deepseq mtl
     parser-combinators scientific text transformers

--- a/test/golden-test-cases/mersenne-random.nix.golden
+++ b/test/golden-test-cases/mersenne-random.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "mersenne-random";
   version = "1.0.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base old-time ];
   homepage = "http://code.haskell.org/~dons/code/mersenne-random";
   description = "Generate high quality pseudorandom numbers using a SIMD Fast Mersenne Twister";

--- a/test/golden-test-cases/messagepack.nix.golden
+++ b/test/golden-test-cases/messagepack.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "messagepack";
   version = "0.5.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring cereal containers deepseq
   ];

--- a/test/golden-test-cases/microlens-ghc.nix.golden
+++ b/test/golden-test-cases/microlens-ghc.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "microlens-ghc";
   version = "0.4.8.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base bytestring containers microlens transformers
   ];

--- a/test/golden-test-cases/microlens.nix.golden
+++ b/test/golden-test-cases/microlens.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "microlens";
   version = "0.4.8.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "http://github.com/aelve/microlens";
   description = "A tiny lens library with no dependencies. If you're writing an app, you probably want microlens-platform, not this.";

--- a/test/golden-test-cases/minio-hs.nix.golden
+++ b/test/golden-test-cases/minio-hs.nix.golden
@@ -11,6 +11,7 @@ mkDerivation {
   pname = "minio-hs";
   version = "0.3.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson async base base64-bytestring bytestring case-insensitive
     conduit conduit-combinators conduit-extra containers cryptonite

--- a/test/golden-test-cases/mmorph.nix.golden
+++ b/test/golden-test-cases/mmorph.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "mmorph";
   version = "1.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base mtl transformers transformers-compat
   ];

--- a/test/golden-test-cases/mnist-idx.nix.golden
+++ b/test/golden-test-cases/mnist-idx.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "mnist-idx";
   version = "0.1.2.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base binary bytestring vector ];
   testHaskellDepends = [ base binary directory hspec vector ];
   homepage = "https://github.com/kryoxide/mnist-idx/";

--- a/test/golden-test-cases/mole.nix.golden
+++ b/test/golden-test-cases/mole.nix.golden
@@ -9,6 +9,7 @@ mkDerivation {
   pname = "mole";
   version = "0.0.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [

--- a/test/golden-test-cases/monad-products.nix.golden
+++ b/test/golden-test-cases/monad-products.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "monad-products";
   version = "4.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base semigroupoids ];
   homepage = "http://github.com/ekmett/monad-products";
   description = "Monad products";

--- a/test/golden-test-cases/monadcryptorandom.nix.golden
+++ b/test/golden-test-cases/monadcryptorandom.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "monadcryptorandom";
   version = "0.7.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring crypto-api exceptions mtl tagged transformers
     transformers-compat

--- a/test/golden-test-cases/monadloc.nix.golden
+++ b/test/golden-test-cases/monadloc.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "monadloc";
   version = "0.7.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base template-haskell transformers ];
   homepage = "http://github.com/pepeiborra/monadloc";
   description = "A class for monads which can keep a monadic call trace";

--- a/test/golden-test-cases/mongoDB.nix.golden
+++ b/test/golden-test-cases/mongoDB.nix.golden
@@ -9,6 +9,7 @@ mkDerivation {
   pname = "mongoDB";
   version = "2.3.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base base16-bytestring base64-bytestring binary bson
     bytestring conduit conduit-extra containers cryptohash

--- a/test/golden-test-cases/monoid-extras.nix.golden
+++ b/test/golden-test-cases/monoid-extras.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "monoid-extras";
   version = "0.4.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base groups semigroupoids semigroups ];
   benchmarkHaskellDepends = [ base criterion ];
   description = "Various extra monoid-related definitions and utilities";

--- a/test/golden-test-cases/mwc-random-monad.nix.golden
+++ b/test/golden-test-cases/mwc-random-monad.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "mwc-random-monad";
   version = "0.7.3.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base monad-primitive mwc-random primitive transformers vector
   ];

--- a/test/golden-test-cases/mwc-random.nix.golden
+++ b/test/golden-test-cases/mwc-random.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "mwc-random";
   version = "0.13.6.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base math-functions primitive time vector
   ];

--- a/test/golden-test-cases/nanospec.nix.golden
+++ b/test/golden-test-cases/nanospec.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "nanospec";
   version = "0.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [ base hspec silently ];
   description = "A lightweight implementation of a subset of Hspec's API";

--- a/test/golden-test-cases/netpbm.nix.golden
+++ b/test/golden-test-cases/netpbm.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "netpbm";
   version = "1.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec attoparsec-binary base bytestring storable-record
     unordered-containers vector vector-th-unbox

--- a/test/golden-test-cases/network-protocol-xmpp.nix.golden
+++ b/test/golden-test-cases/network-protocol-xmpp.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "network-protocol-xmpp";
   version = "0.4.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring gnuidn gnutls gsasl libxml-sax monads-tf network
     text transformers xml-types

--- a/test/golden-test-cases/network-transport-tcp.nix.golden
+++ b/test/golden-test-cases/network-transport-tcp.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "network-transport-tcp";
   version = "0.6.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring containers data-accessor network network-transport
   ];

--- a/test/golden-test-cases/nvim-hs.nix.golden
+++ b/test/golden-test-cases/nvim-hs.nix.golden
@@ -12,6 +12,7 @@ mkDerivation {
   pname = "nvim-hs";
   version = "0.2.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/once.nix.golden
+++ b/test/golden-test-cases/once.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "once";
   version = "0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers hashable template-haskell unordered-containers
   ];

--- a/test/golden-test-cases/one-liner.nix.golden
+++ b/test/golden-test-cases/one-liner.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "one-liner";
   version = "0.9.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bifunctors contravariant ghc-prim profunctors tagged
     transformers

--- a/test/golden-test-cases/online.nix.golden
+++ b/test/golden-test-cases/online.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "online";
   version = "0.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base foldl numhask protolude tdigest vector vector-algorithms
   ];

--- a/test/golden-test-cases/openexr-write.nix.golden
+++ b/test/golden-test-cases/openexr-write.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "openexr-write";
   version = "0.1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base binary bytestring data-binary-ieee754 deepseq split vector
     vector-split zlib

--- a/test/golden-test-cases/openpgp-asciiarmor.nix.golden
+++ b/test/golden-test-cases/openpgp-asciiarmor.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "openpgp-asciiarmor";
   version = "0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base base64-bytestring bytestring cereal
   ];

--- a/test/golden-test-cases/pager.nix.golden
+++ b/test/golden-test-cases/pager.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "pager";
   version = "0.1.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/partial-isomorphisms.nix.golden
+++ b/test/golden-test-cases/partial-isomorphisms.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "partial-isomorphisms";
   version = "0.2.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base template-haskell ];
   homepage = "http://www.informatik.uni-marburg.de/~rendel/unparse";
   description = "Partial isomorphisms";

--- a/test/golden-test-cases/partial-semigroup.nix.golden
+++ b/test/golden-test-cases/partial-semigroup.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "partial-semigroup";
   version = "0.3.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [ base doctest hedgehog ];
   homepage = "https://github.com/chris-martin/partial-semigroup";

--- a/test/golden-test-cases/pathtype.nix.golden
+++ b/test/golden-test-cases/pathtype.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "pathtype";
   version = "0.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/pdfinfo.nix.golden
+++ b/test/golden-test-cases/pdfinfo.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "pdfinfo";
   version = "1.5.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base mtl old-locale process-extras text time time-locale-compat
   ];

--- a/test/golden-test-cases/pell.nix.golden
+++ b/test/golden-test-cases/pell.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "pell";
   version = "0.1.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ arithmoi base containers ];
   testHaskellDepends = [
     arithmoi base Cabal cabal-test-quickcheck containers primes

--- a/test/golden-test-cases/persistable-types-HDBC-pg.nix.golden
+++ b/test/golden-test-cases/persistable-types-HDBC-pg.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "persistable-types-HDBC-pg";
   version = "0.0.1.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring convertible HDBC persistable-record
     relational-query-HDBC text-postgresql

--- a/test/golden-test-cases/persistent-mysql-haskell.nix.golden
+++ b/test/golden-test-cases/persistent-mysql-haskell.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "persistent-mysql-haskell";
   version = "0.3.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/picosat.nix.golden
+++ b/test/golden-test-cases/picosat.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "picosat";
   version = "0.1.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers transformers ];
   testHaskellDepends = [ base containers random rdtsc transformers ];
   homepage = "https://github.com/sdiehl/haskell-picosat";

--- a/test/golden-test-cases/pinch.nix.golden
+++ b/test/golden-test-cases/pinch.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "pinch";
   version = "0.3.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base bytestring containers deepseq ghc-prim hashable text
     unordered-containers vector

--- a/test/golden-test-cases/pipes-network.nix.golden
+++ b/test/golden-test-cases/pipes-network.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "pipes-network";
   version = "0.6.4.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring network network-simple pipes pipes-safe
     transformers

--- a/test/golden-test-cases/pipes-safe.nix.golden
+++ b/test/golden-test-cases/pipes-safe.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "pipes-safe";
   version = "2.2.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers exceptions monad-control mtl pipes primitive
     transformers transformers-base

--- a/test/golden-test-cases/pointed.nix.golden
+++ b/test/golden-test-cases/pointed.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "pointed";
   version = "5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base comonad containers data-default-class hashable kan-extensions
     semigroupoids semigroups stm tagged transformers

--- a/test/golden-test-cases/poly-arity.nix.golden
+++ b/test/golden-test-cases/poly-arity.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "poly-arity";
   version = "0.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base constraints ];
   description = "Tools for working with functions of undetermined arity";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/polynomials-bernstein.nix.golden
+++ b/test/golden-test-cases/polynomials-bernstein.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "polynomials-bernstein";
   version = "1.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base vector ];
   description = "A solver for systems of polynomial equations in bernstein form";
   license = "GPL";

--- a/test/golden-test-cases/postgresql-simple-url.nix.golden
+++ b/test/golden-test-cases/postgresql-simple-url.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "postgresql-simple-url";
   version = "0.2.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base network-uri postgresql-simple split
   ];

--- a/test/golden-test-cases/prelude-safeenum.nix.golden
+++ b/test/golden-test-cases/prelude-safeenum.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "prelude-safeenum";
   version = "0.1.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "http://code.haskell.org/~wren/";
   description = "A redefinition of the Prelude's Enum class in order to render it safe";

--- a/test/golden-test-cases/presburger.nix.golden
+++ b/test/golden-test-cases/presburger.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "presburger";
   version = "1.3.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers pretty ];
   testHaskellDepends = [ base QuickCheck ];
   homepage = "http://github.com/yav/presburger";

--- a/test/golden-test-cases/prettyclass.nix.golden
+++ b/test/golden-test-cases/prettyclass.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "prettyclass";
   version = "1.0.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base pretty ];
   description = "Pretty printing class similar to Show";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/prettyprinter-compat-ansi-wl-pprint.nix.golden
+++ b/test/golden-test-cases/prettyprinter-compat-ansi-wl-pprint.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "prettyprinter-compat-ansi-wl-pprint";
   version = "1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base prettyprinter prettyprinter-ansi-terminal text
   ];

--- a/test/golden-test-cases/prettyprinter-compat-wl-pprint.nix.golden
+++ b/test/golden-test-cases/prettyprinter-compat-wl-pprint.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "prettyprinter-compat-wl-pprint";
   version = "1.0.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base prettyprinter text ];
   homepage = "http://github.com/quchen/prettyprinter";
   description = "Prettyprinter compatibility module for previous users of the wl-pprint package";

--- a/test/golden-test-cases/primitive.nix.golden
+++ b/test/golden-test-cases/primitive.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "primitive";
   version = "0.6.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ghc-prim transformers ];
   testHaskellDepends = [ base ghc-prim ];
   homepage = "https://github.com/haskell/primitive";

--- a/test/golden-test-cases/product-profunctors.nix.golden
+++ b/test/golden-test-cases/product-profunctors.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "product-profunctors";
   version = "0.8.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base contravariant profunctors tagged template-haskell
   ];

--- a/test/golden-test-cases/profiterole.nix.golden
+++ b/test/golden-test-cases/profiterole.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "profiterole";
   version = "0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [

--- a/test/golden-test-cases/projectroot.nix.golden
+++ b/test/golden-test-cases/projectroot.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "projectroot";
   version = "0.2.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base directory ];
   testHaskellDepends = [ base hspec QuickCheck ];
   homepage = "https://github.com/yamadapc/haskell-projectroot";

--- a/test/golden-test-cases/proto-lens-optparse.nix.golden
+++ b/test/golden-test-cases/proto-lens-optparse.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "proto-lens-optparse";
   version = "0.1.0.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base optparse-applicative proto-lens text
   ];

--- a/test/golden-test-cases/proto-lens.nix.golden
+++ b/test/golden-test-cases/proto-lens.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "proto-lens";
   version = "0.2.2.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base bytestring containers data-default-class
     lens-family parsec pretty text transformers void

--- a/test/golden-test-cases/psqueues.nix.golden
+++ b/test/golden-test-cases/psqueues.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "psqueues";
   version = "0.2.4.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base deepseq ghc-prim hashable ];
   testHaskellDepends = [
     array base deepseq ghc-prim hashable HUnit QuickCheck tagged

--- a/test/golden-test-cases/pusher-http-haskell.nix.golden
+++ b/test/golden-test-cases/pusher-http-haskell.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "pusher-http-haskell";
   version = "1.5.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base base16-bytestring bytestring cryptonite hashable
     http-client http-types memory text time transformers

--- a/test/golden-test-cases/quickcheck-arbitrary-adt.nix.golden
+++ b/test/golden-test-cases/quickcheck-arbitrary-adt.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "quickcheck-arbitrary-adt";
   version = "0.2.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base QuickCheck ];
   testHaskellDepends = [
     base hspec lens QuickCheck template-haskell transformers

--- a/test/golden-test-cases/quickcheck-combinators.nix.golden
+++ b/test/golden-test-cases/quickcheck-combinators.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "quickcheck-combinators";
   version = "0.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base QuickCheck unfoldable-restricted ];
   description = "Simple type-level combinators for augmenting QuickCheck instances";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/rank1dynamic.nix.golden
+++ b/test/golden-test-cases/rank1dynamic.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "rank1dynamic";
   version = "0.4.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base binary ];
   testHaskellDepends = [
     base HUnit test-framework test-framework-hunit

--- a/test/golden-test-cases/rasterific-svg.nix.golden
+++ b/test/golden-test-cases/rasterific-svg.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "rasterific-svg";
   version = "0.3.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/ratio-int.nix.golden
+++ b/test/golden-test-cases/ratio-int.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "ratio-int";
   version = "0.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "https://github.com/RaphaelJ/ratio-int";
   description = "Fast specialisation of Data.Ratio for Int.";

--- a/test/golden-test-cases/rawstring-qm.nix.golden
+++ b/test/golden-test-cases/rawstring-qm.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "rawstring-qm";
   version = "0.2.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring template-haskell text ];
   homepage = "https://github.com/tolysz/rawstring-qm";
   description = "Simple raw string quotation and dictionary interpolation";

--- a/test/golden-test-cases/reactive-banana.nix.golden
+++ b/test/golden-test-cases/reactive-banana.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "reactive-banana";
   version = "1.1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers hashable pqueue transformers unordered-containers
     vault

--- a/test/golden-test-cases/rebase.nix.golden
+++ b/test/golden-test-cases/rebase.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "rebase";
   version = "1.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base base-prelude bifunctors bytestring containers contravariant
     contravariant-extras deepseq dlist either fail hashable mtl

--- a/test/golden-test-cases/reform-blaze.nix.golden
+++ b/test/golden-test-cases/reform-blaze.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "reform-blaze";
   version = "0.2.4.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base blaze-html blaze-markup reform text
   ];

--- a/test/golden-test-cases/reform-hsp.nix.golden
+++ b/test/golden-test-cases/reform-hsp.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "reform-hsp";
   version = "0.2.7.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base hsp hsx2hs reform text ];
   homepage = "http://www.happstack.com/";
   description = "Add support for using HSP with Reform";

--- a/test/golden-test-cases/regex-compat.nix.golden
+++ b/test/golden-test-cases/regex-compat.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "regex-compat";
   version = "0.95.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ array base regex-base regex-posix ];
   homepage = "http://sourceforge.net/projects/lazy-regex";
   description = "Replaces/Enhances Text.Regex";

--- a/test/golden-test-cases/regex-pcre.nix.golden
+++ b/test/golden-test-cases/regex-pcre.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "regex-pcre";
   version = "0.94.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base bytestring containers regex-base
   ];

--- a/test/golden-test-cases/relational-query.nix.golden
+++ b/test/golden-test-cases/relational-query.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "relational-query";
   version = "0.11.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base bytestring containers dlist names-th persistable-record
     product-isomorphic sql-words template-haskell text th-reify-compat

--- a/test/golden-test-cases/relational-schemas.nix.golden
+++ b/test/golden-test-cases/relational-schemas.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "relational-schemas";
   version = "0.1.6.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring containers relational-query template-haskell time
   ];

--- a/test/golden-test-cases/repa-io.nix.golden
+++ b/test/golden-test-cases/repa-io.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "repa-io";
   version = "3.4.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base binary bmp bytestring old-time repa vector
   ];

--- a/test/golden-test-cases/repa.nix.golden
+++ b/test/golden-test-cases/repa.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "repa";
   version = "3.4.1.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring ghc-prim QuickCheck template-haskell vector
   ];

--- a/test/golden-test-cases/rosezipper.nix.golden
+++ b/test/golden-test-cases/rosezipper.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "rosezipper";
   version = "0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers ];
   description = "Generic zipper implementation for Data.Tree";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/rvar.nix.golden
+++ b/test/golden-test-cases/rvar.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "rvar";
   version = "0.2.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base MonadPrompt mtl random-source transformers
   ];

--- a/test/golden-test-cases/scalpel-core.nix.golden
+++ b/test/golden-test-cases/scalpel-core.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "scalpel-core";
   version = "0.5.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring containers data-default fail regex-base regex-tdfa
     tagsoup text vector

--- a/test/golden-test-cases/sdl2.nix.golden
+++ b/test/golden-test-cases/sdl2.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "sdl2";
   version = "2.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/selda-sqlite.nix.golden
+++ b/test/golden-test-cases/selda-sqlite.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "selda-sqlite";
   version = "0.1.6.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base direct-sqlite directory exceptions selda text
   ];

--- a/test/golden-test-cases/selda.nix.golden
+++ b/test/golden-test-cases/selda.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "selda";
   version = "0.1.11.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring exceptions hashable mtl psqueues text time
     unordered-containers

--- a/test/golden-test-cases/servant-checked-exceptions.nix.golden
+++ b/test/golden-test-cases/servant-checked-exceptions.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "servant-checked-exceptions";
   version = "0.4.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/set-cover.nix.golden
+++ b/test/golden-test-cases/set-cover.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "set-cover";
   version = "0.0.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/sets.nix.golden
+++ b/test/golden-test-cases/sets.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "sets";
   version = "0.0.5.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base commutative composition containers contravariant hashable keys
     mtl QuickCheck semigroupoids semigroups transformers

--- a/test/golden-test-cases/simple-smt.nix.golden
+++ b/test/golden-test-cases/simple-smt.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "simple-smt";
   version = "0.7.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base process ];
   description = "A simple way to interact with an SMT solver process";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/slack-web.nix.golden
+++ b/test/golden-test-cases/slack-web.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "slack-web";
   version = "0.2.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base containers errors http-api-data http-client
     http-client-tls megaparsec mtl servant servant-client text time

--- a/test/golden-test-cases/slug.nix.golden
+++ b/test/golden-test-cases/slug.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "slug";
   version = "0.1.7";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base exceptions http-api-data path-pieces persistent
     QuickCheck text

--- a/test/golden-test-cases/soxlib.nix.golden
+++ b/test/golden-test-cases/soxlib.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "soxlib";
   version = "0.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/speedy-slice.nix.golden
+++ b/test/golden-test-cases/speedy-slice.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "speedy-slice";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base kan-extensions lens mcmc-types mwc-probability pipes primitive
     transformers

--- a/test/golden-test-cases/splice.nix.golden
+++ b/test/golden-test-cases/splice.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "splice";
   version = "0.6.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base network ];
   homepage = "http://corsis.github.com/splice/";
   description = "Cross-platform Socket to Socket Data Splicing";

--- a/test/golden-test-cases/spreadsheet.nix.golden
+++ b/test/golden-test-cases/spreadsheet.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "spreadsheet";
   version = "0.1.3.7";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/stack-type.nix.golden
+++ b/test/golden-test-cases/stack-type.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "stack-type";
   version = "0.1.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base transformers ];
   homepage = "https://github.com/aiya000/hs-stack-type";
   description = "The basic stack type";

--- a/test/golden-test-cases/state-codes.nix.golden
+++ b/test/golden-test-cases/state-codes.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "state-codes";
   version = "0.1.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ aeson base shakespeare text ];
   testHaskellDepends = [ aeson base hspec QuickCheck text ];
   homepage = "https://github.com/acamino/state-codes#README";

--- a/test/golden-test-cases/stb-image-redux.nix.golden
+++ b/test/golden-test-cases/stb-image-redux.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "stb-image-redux";
   version = "0.2.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base vector ];
   testHaskellDepends = [ base hspec vector ];
   homepage = "https://github.com/typedrat/stb-image-redux#readme";

--- a/test/golden-test-cases/stm-containers.nix.golden
+++ b/test/golden-test-cases/stm-containers.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "stm-containers";
   version = "0.2.16";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base base-prelude focus hashable list-t primitive transformers
   ];

--- a/test/golden-test-cases/streaming-commons.nix.golden
+++ b/test/golden-test-cases/streaming-commons.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "streaming-commons";
   version = "0.1.18";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array async base blaze-builder bytestring directory network process
     random stm text transformers unix zlib

--- a/test/golden-test-cases/strict-base-types.nix.golden
+++ b/test/golden-test-cases/strict-base-types.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "strict-base-types";
   version = "0.5.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bifunctors binary deepseq ghc-prim hashable lens
     QuickCheck strict

--- a/test/golden-test-cases/strict-types.nix.golden
+++ b/test/golden-test-cases/strict-types.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "strict-types";
   version = "0.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array base bytestring containers deepseq hashable text
     unordered-containers vector

--- a/test/golden-test-cases/string-class.nix.golden
+++ b/test/golden-test-cases/string-class.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "string-class";
   version = "0.1.6.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring tagged text ];
   homepage = "https://github.com/bairyn/string-class";
   description = "String class library";

--- a/test/golden-test-cases/stripe-haskell.nix.golden
+++ b/test/golden-test-cases/stripe-haskell.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "stripe-haskell";
   version = "2.2.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base stripe-core stripe-http-streams ];
   homepage = "https://github.com/dmjio/stripe";
   description = "Stripe API for Haskell";

--- a/test/golden-test-cases/svg-tree.nix.golden
+++ b/test/golden-test-cases/svg-tree.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "svg-tree";
   version = "0.6.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base bytestring containers JuicyPixels lens linear mtl
     scientific text transformers vector xml

--- a/test/golden-test-cases/swagger.nix.golden
+++ b/test/golden-test-cases/swagger.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "swagger";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bytestring text time transformers
   ];

--- a/test/golden-test-cases/system-argv0.nix.golden
+++ b/test/golden-test-cases/system-argv0.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "system-argv0";
   version = "0.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring system-filepath text ];
   homepage = "https://john-millikin.com/software/haskell-filesystem/";
   description = "Get argv[0] as a FilePath";

--- a/test/golden-test-cases/system-fileio.nix.golden
+++ b/test/golden-test-cases/system-fileio.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "system-fileio";
   version = "0.3.16.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring system-filepath text time unix
   ];

--- a/test/golden-test-cases/tagged.nix.golden
+++ b/test/golden-test-cases/tagged.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "tagged";
   version = "0.8.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base deepseq template-haskell transformers transformers-compat
   ];

--- a/test/golden-test-cases/taggy.nix.golden
+++ b/test/golden-test-cases/taggy.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "taggy";
   version = "0.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   enableSeparateDataOutput = true;

--- a/test/golden-test-cases/tagstream-conduit.nix.golden
+++ b/test/golden-test-cases/tagstream-conduit.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "tagstream-conduit";
   version = "0.5.5.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     attoparsec base blaze-builder bytestring case-insensitive conduit
     conduit-extra data-default resourcet text transformers xml-conduit

--- a/test/golden-test-cases/tasty-hedgehog.nix.golden
+++ b/test/golden-test-cases/tasty-hedgehog.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "tasty-hedgehog";
   version = "0.1.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base hedgehog tagged tasty ];
   testHaskellDepends = [
     base hedgehog tasty tasty-expected-failure

--- a/test/golden-test-cases/tasty-rerun.nix.golden
+++ b/test/golden-test-cases/tasty-rerun.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "tasty-rerun";
   version = "1.1.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers mtl optparse-applicative reducers split stm tagged
     tasty transformers

--- a/test/golden-test-cases/tce-conf.nix.golden
+++ b/test/golden-test-cases/tce-conf.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "tce-conf";
   version = "1.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base containers ];

--- a/test/golden-test-cases/terminal-progress-bar.nix.golden
+++ b/test/golden-test-cases/terminal-progress-bar.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "terminal-progress-bar";
   version = "0.1.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base stm stm-chans ];

--- a/test/golden-test-cases/test-fixture.nix.golden
+++ b/test/golden-test-cases/test-fixture.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "test-fixture";
   version = "0.5.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base data-default-class exceptions haskell-src-exts
     haskell-src-meta mtl template-haskell th-orphans

--- a/test/golden-test-cases/texmath.nix.golden
+++ b/test/golden-test-cases/texmath.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "texmath";
   version = "0.10.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/text-icu.nix.golden
+++ b/test/golden-test-cases/text-icu.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "text-icu";
   version = "0.7.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring deepseq text ];
   librarySystemDepends = [ icu ];
   testHaskellDepends = [

--- a/test/golden-test-cases/text-postgresql.nix.golden
+++ b/test/golden-test-cases/text-postgresql.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "text-postgresql";
   version = "0.0.2.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base dlist transformers transformers-compat
   ];

--- a/test/golden-test-cases/th-expand-syns.nix.golden
+++ b/test/golden-test-cases/th-expand-syns.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "th-expand-syns";
   version = "0.4.4.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers syb template-haskell ];
   testHaskellDepends = [ base template-haskell ];
   homepage = "https://github.com/DanielSchuessler/th-expand-syns";

--- a/test/golden-test-cases/these.nix.golden
+++ b/test/golden-test-cases/these.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "these";
   version = "0.7.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base bifunctors binary containers data-default-class deepseq
     hashable keys mtl profunctors QuickCheck semigroupoids transformers

--- a/test/golden-test-cases/timezone-series.nix.golden
+++ b/test/golden-test-cases/timezone-series.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "timezone-series";
   version = "0.1.8";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base deepseq time ];
   homepage = "http://projects.haskell.org/time-ng/";
   description = "Enhanced timezone handling for Data.Time";

--- a/test/golden-test-cases/transformers-compat.nix.golden
+++ b/test/golden-test-cases/transformers-compat.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "transformers-compat";
   version = "0.5.1.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ghc-prim transformers ];
   homepage = "http://github.com/ekmett/transformers-compat/";
   description = "A small compatibility shim exposing the new types from transformers 0.3 and 0.4 to older Haskell platforms.";

--- a/test/golden-test-cases/transformers-lift.nix.golden
+++ b/test/golden-test-cases/transformers-lift.nix.golden
@@ -4,6 +4,7 @@ mkDerivation {
   pname = "transformers-lift";
   version = "0.2.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base transformers writer-cps-transformers
   ];

--- a/test/golden-test-cases/tree-fun.nix.golden
+++ b/test/golden-test-cases/tree-fun.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "tree-fun";
   version = "0.8.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers mtl ];
   description = "Library for functions pertaining to tree exploration and manipulation";
   license = stdenv.lib.licenses.gpl3;

--- a/test/golden-test-cases/ttrie.nix.golden
+++ b/test/golden-test-cases/ttrie.nix.golden
@@ -8,6 +8,7 @@ mkDerivation {
   pname = "ttrie";
   version = "0.1.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     atomic-primops base hashable primitive stm
   ];

--- a/test/golden-test-cases/tuple-th.nix.golden
+++ b/test/golden-test-cases/tuple-th.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "tuple-th";
   version = "0.2.5";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers template-haskell ];
   description = "Generate (non-recursive) utility functions for tuples of statically known size";
   license = stdenv.lib.licenses.bsd3;

--- a/test/golden-test-cases/tuples-homogenous-h98.nix.golden
+++ b/test/golden-test-cases/tuples-homogenous-h98.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "tuples-homogenous-h98";
   version = "0.1.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   homepage = "https://github.com/ppetr/tuples-homogenous-h98";
   description = "Wrappers for n-ary tuples with Traversable and Applicative/Monad instances";

--- a/test/golden-test-cases/turtle-options.nix.golden
+++ b/test/golden-test-cases/turtle-options.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "turtle-options";
   version = "0.1.0.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base optional-args parsec text turtle ];

--- a/test/golden-test-cases/type-operators.nix.golden
+++ b/test/golden-test-cases/type-operators.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "type-operators";
   version = "0.1.0.4";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ghc-prim ];
   homepage = "https://github.com/Shou/type-operators#readme";
   description = "Various type-level operators";

--- a/test/golden-test-cases/type-spec.nix.golden
+++ b/test/golden-test-cases/type-spec.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "type-spec";
   version = "0.3.0.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base pretty ];
   testHaskellDepends = [ base ];
   homepage = "https://github.com/sheyll/type-spec#readme";

--- a/test/golden-test-cases/unicode-show.nix.golden
+++ b/test/golden-test-cases/unicode-show.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "unicode-show";
   version = "0.1.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [
     base HUnit QuickCheck test-framework test-framework-hunit

--- a/test/golden-test-cases/unique.nix.golden
+++ b/test/golden-test-cases/unique.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "unique";
   version = "0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ghc-prim hashable ];
   homepage = "http://github.com/ekmett/unique/";
   description = "Fully concurrent unique identifiers";

--- a/test/golden-test-cases/unix-bytestring.nix.golden
+++ b/test/golden-test-cases/unix-bytestring.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "unix-bytestring";
   version = "0.3.7.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring ];
   homepage = "http://code.haskell.org/~wren/";
   description = "Unix/Posix-specific functions for ByteStrings";

--- a/test/golden-test-cases/unlit.nix.golden
+++ b/test/golden-test-cases/unlit.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "unlit";
   version = "0.4.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base directory text ];

--- a/test/golden-test-cases/utility-ht.nix.golden
+++ b/test/golden-test-cases/utility-ht.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "utility-ht";
   version = "0.0.14";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [ base QuickCheck ];
   description = "Various small helper functions for Lists, Maybes, Tuples, Functions";

--- a/test/golden-test-cases/validity-aeson.nix.golden
+++ b/test/golden-test-cases/validity-aeson.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "validity-aeson";
   version = "0.1.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base validity validity-scientific validity-text
     validity-unordered-containers validity-vector

--- a/test/golden-test-cases/validity-containers.nix.golden
+++ b/test/golden-test-cases/validity-containers.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "validity-containers";
   version = "0.2.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base containers validity ];
   homepage = "https://github.com/NorfairKing/validity#readme";
   description = "Validity instances for containers";

--- a/test/golden-test-cases/vector-mmap.nix.golden
+++ b/test/golden-test-cases/vector-mmap.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "vector-mmap";
   version = "0.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base mmap primitive vector ];
   testHaskellDepends = [ base QuickCheck temporary vector ];
   homepage = "http://github.com/pumpkin/vector-mmap";

--- a/test/golden-test-cases/vivid-supercollider.nix.golden
+++ b/test/golden-test-cases/vivid-supercollider.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "vivid-supercollider";
   version = "0.3.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base binary bytestring cereal split utf8-string vivid-osc
   ];

--- a/test/golden-test-cases/vty.nix.golden
+++ b/test/golden-test-cases/vty.nix.golden
@@ -10,6 +10,7 @@ mkDerivation {
   pname = "vty";
   version = "5.19.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/wai-cors.nix.golden
+++ b/test/golden-test-cases/wai-cors.nix.golden
@@ -7,6 +7,7 @@ mkDerivation {
   pname = "wai-cors";
   version = "0.2.6";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     attoparsec base base-unicode-symbols bytestring case-insensitive

--- a/test/golden-test-cases/wai-middleware-auth.nix.golden
+++ b/test/golden-test-cases/wai-middleware-auth.nix.golden
@@ -10,6 +10,7 @@ mkDerivation {
   pname = "wai-middleware-auth";
   version = "0.1.2.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/test/golden-test-cases/wai-middleware-caching-redis.nix.golden
+++ b/test/golden-test-cases/wai-middleware-caching-redis.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "wai-middleware-caching-redis";
   version = "0.2.0.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base blaze-builder bytestring hedis http-types text wai
     wai-middleware-caching

--- a/test/golden-test-cases/wai-middleware-prometheus.nix.golden
+++ b/test/golden-test-cases/wai-middleware-prometheus.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "wai-middleware-prometheus";
   version = "0.3.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring clock data-default http-types prometheus-client
     text wai

--- a/test/golden-test-cases/warp.nix.golden
+++ b/test/golden-test-cases/warp.nix.golden
@@ -10,6 +10,7 @@ mkDerivation {
   pname = "warp";
   version = "3.2.13";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     array async auto-update base blaze-builder bytestring
     bytestring-builder case-insensitive containers ghc-prim hashable

--- a/test/golden-test-cases/weigh.nix.golden
+++ b/test/golden-test-cases/weigh.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "weigh";
   version = "0.0.7";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base deepseq mtl process split template-haskell temporary
   ];

--- a/test/golden-test-cases/xml-hamlet.nix.golden
+++ b/test/golden-test-cases/xml-hamlet.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "xml-hamlet";
   version = "0.4.1.1";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base containers parsec shakespeare template-haskell text
     xml-conduit

--- a/test/golden-test-cases/xmonad-contrib.nix.golden
+++ b/test/golden-test-cases/xmonad-contrib.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "xmonad-contrib";
   version = "0.13";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base bytestring containers directory extensible-exceptions filepath
     mtl old-locale old-time process random unix utf8-string X11 X11-xft

--- a/test/golden-test-cases/yahoo-finance-api.nix.golden
+++ b/test/golden-test-cases/yahoo-finance-api.nix.golden
@@ -6,6 +6,7 @@ mkDerivation {
   pname = "yahoo-finance-api";
   version = "0.2.0.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     aeson base either http-api-data http-client mtl servant
     servant-client text time transformers vector

--- a/test/golden-test-cases/yesod-form-bootstrap4.nix.golden
+++ b/test/golden-test-cases/yesod-form-bootstrap4.nix.golden
@@ -3,6 +3,7 @@ mkDerivation {
   pname = "yesod-form-bootstrap4";
   version = "0.1.0.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base classy-prelude-yesod yesod-form ];
   homepage = "https://github.com/ncaq/yesod-form-bootstrap4#readme";
   description = "renderBootstrap4";

--- a/test/golden-test-cases/yesod-gitrepo.nix.golden
+++ b/test/golden-test-cases/yesod-gitrepo.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "yesod-gitrepo";
   version = "0.2.1.0";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base directory enclosed-exceptions http-types lifted-base process
     temporary text wai yesod-core

--- a/test/golden-test-cases/yesod-recaptcha2.nix.golden
+++ b/test/golden-test-cases/yesod-recaptcha2.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "yesod-recaptcha2";
   version = "0.2.3";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [
     base classy-prelude-yesod http-conduit yesod-auth
   ];

--- a/test/golden-test-cases/zlib.nix.golden
+++ b/test/golden-test-cases/zlib.nix.golden
@@ -5,6 +5,7 @@ mkDerivation {
   pname = "zlib";
   version = "0.6.1.2";
   sha256 = "deadbeef";
+  isSimpleBuild = true;
   libraryHaskellDepends = [ base bytestring ];
   librarySystemDepends = [ zlib ];
   testHaskellDepends = [


### PR DESCRIPTION
This will allow generic-builder.nix to use a shared Setup executable for all
packages that have `isSimpleBuild = true`. The default must be false, for
safety, even though almost all packages are simple.