### PR TITLE
Include cabal-version field inferred by hpack

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -216,7 +216,10 @@ hpackDirectory dir = do
   case mPackage of
     Left err -> liftIO $ hPutStrLn stderr ("*** hpack error: " ++ show err ++ ". Exiting.") >> exitFailure
     Right r -> do
-      let hpackOutput = encodeUtf8 $ Hpack.renderPackage [] (Hpack.decodeResultPackage r)
+      let hpackOutput =
+            let body = Hpack.renderPackage [] (Hpack.decodeResultPackage r)
+                cabalVersion = Hpack.decodeResultCabalVersion r
+            in encodeUtf8 $ cabalVersion ++ body
           hash = printSHA256 $ digest (digestByName "sha256") hpackOutput
       case runParseGenericPackageDescription "<hpack output>" hpackOutput of
         Left msg -> liftIO $ do


### PR DESCRIPTION
hpack infers a cabal-version field based on the features used by the
package. This field is required because it may change how Cabal parses the
package description.