### PR TITLE
add benchmark enabling flag

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -49,6 +49,7 @@ data Options = Options
   , optHpack :: Bool
   , optDoCheck :: Bool
   , optJailbreak :: Bool
+  , optDoBenchmark :: Bool
   , optRevision :: Maybe String
   , optHyperlinkSource :: Bool
   , optEnableLibraryProfiling :: Bool
@@ -76,6 +77,7 @@ options = Options
           <*> switch (long "hpack" <> help "run hpack before configuring this package (only non-hackage packages)")
           <*> flag True False (long "no-check" <> help "don't run regression test suites of this package")
           <*> switch (long "jailbreak" <> help "disregard version restrictions on build inputs")
+          <*> switch (long "benchmark" <> help "enable benchmarks for this package")
           <*> optional (strOption $ long "revision" <> help "revision to use when fetching from VCS")
           <*> flag True False (long "no-hyperlink-source" <> help "don't generate pretty-printed source code for the documentation")
           <*> switch (long "enable-library-profiling" <> help "enable library profiling in the generated build")
@@ -228,6 +230,7 @@ processPackage Options{..} pkg = do
               & metaSection.maintainers .~ Set.fromList (map (review ident) optMaintainer)
 --            & metaSection.platforms .~ Set.fromList optPlatform
               & doCheck &&~ optDoCheck
+              & doBenchmark ||~ optDoBenchmark
               & extraFunctionArgs %~ Set.union (Set.fromList ("inherit stdenv":map (fromString . ("inherit " ++)) optExtraArgs))
 
       shell :: Doc

--- a/src/Distribution/Nixpkgs/Haskell/Derivation.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Derivation.hs
@@ -7,7 +7,7 @@
 module Distribution.Nixpkgs.Haskell.Derivation
   ( Derivation, nullDerivation, pkgid, revision, src, subpath, isLibrary, isExecutable
   , extraFunctionArgs, libraryDepends, executableDepends, testDepends, configureFlags
-  , cabalFlags, runHaddock, jailbreak, doCheck, testTarget, hyperlinkSource, enableSplitObjs
+  , cabalFlags, runHaddock, jailbreak, doCheck, doBenchmark, testTarget, hyperlinkSource, enableSplitObjs
   , enableLibraryProfiling, enableExecutableProfiling, phaseOverrides, editedCabalFile, metaSection
   , dependencies, setupDepends, benchmarkDepends, enableSeparateDataOutput
   )
@@ -55,6 +55,7 @@ data Derivation = MkDerivation
   , _runHaddock                 :: Bool
   , _jailbreak                  :: Bool
   , _doCheck                    :: Bool
+  , _doBenchmark                :: Bool
   , _testTarget                 :: String
   , _hyperlinkSource            :: Bool
   , _enableLibraryProfiling     :: Bool
@@ -86,6 +87,7 @@ nullDerivation = MkDerivation
   , _runHaddock = error "undefined Derivation.runHaddock"
   , _jailbreak = error "undefined Derivation.jailbreak"
   , _doCheck = error "undefined Derivation.doCheck"
+  , _doBenchmark = error "undefined Derivation.doBenchmark"
   , _testTarget = error "undefined Derivation.testTarget"
   , _hyperlinkSource = error "undefined Derivation.hyperlinkSource"
   , _enableLibraryProfiling = error "undefined Derivation.enableLibraryProfiling"
@@ -131,6 +133,7 @@ instance Pretty Derivation where
       , boolattr "doHaddock" (not _runHaddock) _runHaddock
       , boolattr "jailbreak" _jailbreak _jailbreak
       , boolattr "doCheck" (not _doCheck) _doCheck
+      , boolattr "doBenchmark" _doBenchmark _doBenchmark
       , onlyIf (not (null _testTarget)) $ attr "testTarget" $ string _testTarget
       , boolattr "hyperlinkSource" (not _hyperlinkSource) _hyperlinkSource
       , onlyIf (not (null _phaseOverrides)) $ vcat ((map text . lines) _phaseOverrides)

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -91,6 +91,7 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
     & runHaddock .~ doHaddockPhase
     & jailbreak .~ False
     & doCheck .~ True
+    & doBenchmark .~ False
     & testTarget .~ mempty
     & hyperlinkSource .~ True
     & enableSplitObjs .~ True


### PR DESCRIPTION
cabal2nix already provides flags for haddocks generation and enabling
tests so it makes sense to allow enabling package benchmarks as well.

Fixes #396 