### PR TITLE
Put file src attribute in quotes to allow more paths

### DIFF
--- a/src/Distribution/Nixpkgs/Fetch.hs
+++ b/src/Distribution/Nixpkgs/Fetch.hs
@@ -78,7 +78,7 @@ instance PP.Pretty DerivationSource where
     let isHackagePackage = "mirror://hackage/" `L.isPrefixOf` derivUrl
         fetched = derivKind /= ""
     in if isHackagePackage then attr "sha256" $ string derivHash
-       else if not fetched then attr "src" $ text derivUrl
+       else if not fetched then attr "src" $ string derivUrl
             else vcat
                  [ text "src" <+> equals <+> text ("fetch" ++ derivKind) <+> lbrace
                  , nest 2 $ vcat


### PR DESCRIPTION
Nix paths allow only limited set of characters thus for example paths with "@" of paths with non-latin characters give derivation with Nix fails to parse. Quoting resolves this problem.