### PR TITLE
Revert "Revert "Disable Haddock phase for packages with internal libraries.""

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -88,7 +88,7 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
     & Nix.setupDepends .~ maybe mempty convertSetupBuildInfo setupBuildInfo
     & configureFlags .~ mempty
     & cabalFlags .~ flags
-    & runHaddock .~ maybe True (not . null . exposedModules) library
+    & runHaddock .~ doHaddockPhase
     & jailbreak .~ False
     & doCheck .~ True
     & doBenchmark .~ False
@@ -149,6 +149,11 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
 
     internalLibNames :: [PackageName]
     internalLibNames = fmap unqualComponentNameToPackageName . catMaybes $ libName <$> subLibraries
+
+    doHaddockPhase :: Bool
+    doHaddockPhase | not (null internalLibNames) = False
+                   | Just l <- library           = not (null (exposedModules l))
+                   | otherwise                   = True
 
     convertBuildInfo :: Cabal.BuildInfo -> Nix.BuildInfo
     convertBuildInfo Cabal.BuildInfo {..} | not buildable = mempty

--- a/test/golden-test-cases/haddock-library.cabal
+++ b/test/golden-test-cases/haddock-library.cabal
@@ -1,0 +1,130 @@
+name:                 haddock-library
+version:              1.4.5
+synopsis:             Library exposing some functionality of Haddock.
+description:          Haddock is a documentation-generation tool for Haskell
+                      libraries. These modules expose some functionality of it
+                      without pulling in the GHC dependency. Please note that the
+                      API is likely to change so specify upper bounds in your
+                      project if you can't release often. For interacting with Haddock
+                      itself, see the ‘haddock’ package.
+license:              BSD3
+license-file:         LICENSE
+maintainer:           Alex Biehl <alexbiehl@gmail.com>, Simon Hengel <sol@typeful.net>, Mateusz Kowalczyk <fuuzetsu@fuuzetsu.co.uk>
+homepage:             http://www.haskell.org/haddock/
+bug-reports:          https://github.com/haskell/haddock/issues
+category:             Documentation
+build-type:           Simple
+cabal-version:        >= 2.0
+extra-source-files:
+  CHANGES.md
+library
+  default-language:     Haskell2010
+
+  build-depends:
+      base         >= 4.5     && < 4.11
+    , bytestring   >= 0.9.2.1 && < 0.11
+    , transformers >= 0.3.0   && < 0.6
+
+  -- internal sub-lib
+  build-depends:        attoparsec
+
+  hs-source-dirs:       src
+  ghc-options:          -funbox-strict-fields -Wall -fwarn-tabs -O2
+
+  exposed-modules:
+    Documentation.Haddock.Doc
+    Documentation.Haddock.Markup
+    Documentation.Haddock.Parser
+    Documentation.Haddock.Parser.Monad
+    Documentation.Haddock.Types
+    Documentation.Haddock.Utf8
+
+  other-modules:
+    Documentation.Haddock.Parser.Util
+
+  ghc-options: -Wall
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+
+library attoparsec
+  default-language:     Haskell2010
+
+  build-depends:
+      base         >= 4.5     && < 4.11
+    , bytestring   >= 0.9.2.1 && < 0.11
+    , deepseq      >= 1.3     && < 1.5
+
+  hs-source-dirs:       vendor/attoparsec-0.13.1.0
+
+  -- NB: haddock-library needs only small part of lib:attoparsec
+  --     internally, so we only bundle that subset here
+  exposed-modules:
+    Data.Attoparsec.ByteString
+    Data.Attoparsec.ByteString.Char8
+
+  other-modules:
+    Data.Attoparsec
+    Data.Attoparsec.ByteString.Buffer
+    Data.Attoparsec.ByteString.FastSet
+    Data.Attoparsec.ByteString.Internal
+    Data.Attoparsec.Combinator
+    Data.Attoparsec.Internal
+    Data.Attoparsec.Internal.Fhthagn
+    Data.Attoparsec.Internal.Types
+    Data.Attoparsec.Number
+
+  ghc-options:          -funbox-strict-fields -Wall -fwarn-tabs -O2
+
+  ghc-options: -Wall
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+  else
+    build-depends: semigroups ^>= 0.18.3, fail ^>= 4.9.0.0
+
+
+test-suite spec
+  type:             exitcode-stdio-1.0
+  default-language: Haskell2010
+  main-is:          Spec.hs
+  hs-source-dirs:
+      test
+    , src
+  ghc-options: -Wall
+
+  cpp-options:
+      -DTEST
+
+  other-modules:
+      Documentation.Haddock.Doc
+      Documentation.Haddock.Parser
+      Documentation.Haddock.Parser.Monad
+      Documentation.Haddock.Parser.Util
+      Documentation.Haddock.Parser.UtilSpec
+      Documentation.Haddock.ParserSpec
+      Documentation.Haddock.Types
+      Documentation.Haddock.Utf8
+      Documentation.Haddock.Utf8Spec
+
+  build-depends:
+      base-compat   ^>= 0.9.3
+    , transformers   >= 0.3.0   && < 0.6
+    , hspec         ^>= 2.4.4
+    , QuickCheck    ^>= 2.10
+
+  -- internal sub-lib
+  build-depends: attoparsec
+
+  -- Versions for the dependencies below are transitively pinned by
+  -- dependency on haddock-library:lib:attoparsec
+  build-depends:
+      base
+    , bytestring
+    , deepseq
+
+  build-tool-depends:
+    hspec-discover:hspec-discover ^>= 2.4.4
+
+source-repository head
+  type:     git
+  subdir:   haddock-library
+  location: https://github.com/haskell/haddock.git

--- a/test/golden-test-cases/haddock-library.nix.golden
+++ b/test/golden-test-cases/haddock-library.nix.golden
@@ -1,0 +1,17 @@
+{ mkDerivation, base, base-compat, bytestring, deepseq, hspec
+, hspec-discover, QuickCheck, stdenv, transformers
+}:
+mkDerivation {
+  pname = "haddock-library";
+  version = "1.4.5";
+  sha256 = "deadbeef";
+  libraryHaskellDepends = [ base bytestring deepseq transformers ];
+  testHaskellDepends = [
+    base base-compat bytestring deepseq hspec QuickCheck transformers
+  ];
+  testToolDepends = [ hspec-discover ];
+  doHaddock = false;
+  homepage = "http://www.haskell.org/haddock/";
+  description = "Library exposing some functionality of Haddock";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
Reverts NixOS/cabal2nix#405. This change breaks several builds. See https://hydra.nixos.org/build/88843163 for an example.

Cc: @shlevy 