### PR TITLE
resolveInNixpkgs: stop using GNOME aliases

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -136,10 +136,10 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
     resolveInNixpkgs :: Identifier -> Binding
     resolveInNixpkgs i
       | i `elem` ["clang","lldb","llvm"] = binding # (i, path # ["self","llvmPackages",i])     -- TODO: evil!
-      | i == "gtk2"                      = binding # (i, path # ["pkgs","gnome2","gtk"])
-      | i == "gtk3"                      = binding # (i, path # ["pkgs","gnome3","gtk"])
-      | i == "gtksourceview3"            = binding # (i, path # ["pkgs","gnome3","gtksourceview"])
-      | i == "vte_291"                  = binding # (i, path # ["pkgs","gnome3","vte"])
+      | i == "gtk2"                      = binding # (i, path # ["pkgs","gtk2"])
+      | i == "gtk3"                      = binding # (i, path # ["pkgs","gtk3"])
+      | i == "gtksourceview3"            = binding # (i, path # ["pkgs","gtksourceview3"])
+      | i == "vte_291"                  = binding # (i, path # ["pkgs","vte"])
       | Just p <- nixpkgsResolver i, init (view (reference . path) p) `Set.member` goodScopes = p
       | otherwise                        = bindNull i
 


### PR DESCRIPTION
They were removed in https://github.com/NixOS/nixpkgs/pull/55735