### PR TITLE
Add a minimal version contstraint for 'containers'.

### DIFF
--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -112,7 +112,7 @@ library
                     , aeson                > 1
                     , ansi-wl-pprint
                     , bytestring
-                    , containers
+                    , containers           >= 0.5.9
                     , deepseq              >= 1.4
                     , directory
                     , distribution-nixpkgs >= 1.2


### PR DESCRIPTION
The library uses [Map.!?](https://hackage.haskell.org/package/containers-0.6.0.1/docs/Data-Map-Internal.html#v:-33--63-) which is only available since containers-0.5.9.

It failed to build on my machine because of this issue.