### PR TITLE
Don't hardcode $doc

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -291,8 +291,8 @@ darcsInstallPostInstall = unlines
 xmonadPostInstall :: String
 xmonadPostInstall = unlines
   [ "postInstall = ''"
-  , "  install -D man/xmonad.1 $doc/share/man/man1/xmonad.1"
-  , "  install -D man/xmonad.hs $doc/share/doc/$name/sample-xmonad.hs"
+  , "  install -D man/xmonad.1 ${!outputDoc}/share/man/man1/xmonad.1"
+  , "  install -D man/xmonad.hs ${!outputDoc}/share/doc/$name/sample-xmonad.hs"
   , "'';"
   ]
 


### PR DESCRIPTION
Split outputs can be disabled, in which case $doc is the empty string.

`outputDoc` always points to the right output variable name
(either "out" or "doc").

See also https://github.com/NixOS/nixpkgs/pull/61526.