### PR TITLE
xmonad: Fix missing dollar escape quotes.

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -291,8 +291,8 @@ darcsInstallPostInstall = unlines
 xmonadPostInstall :: String
 xmonadPostInstall = unlines
   [ "postInstall = ''"
-  , "  install -D man/xmonad.1 ${!outputDoc}/share/man/man1/xmonad.1"
-  , "  install -D man/xmonad.hs ${!outputDoc}/share/doc/$name/sample-xmonad.hs"
+  , "  install -D man/xmonad.1 ''${!outputDoc}/share/man/man1/xmonad.1"
+  , "  install -D man/xmonad.hs ''${!outputDoc}/share/doc/$name/sample-xmonad.hs"
   , "'';"
   ]
 


### PR DESCRIPTION
See https://github.com/NixOS/cabal2nix/pull/416#issuecomment-494096785