### PR TITLE
Run hpack in prePatch phase

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -193,7 +193,7 @@ main = bracket (return ()) (\() -> hFlush stdout >> hFlush stderr) $ \() ->
   cabal2nix =<< getArgs
 
 hpackOverrides :: Derivation -> Derivation
-hpackOverrides = over phaseOverrides (++ "preConfigure = \"hpack\";")
+hpackOverrides = over phaseOverrides (++ "prePatch = \"hpack\";")
                . set (libraryDepends . tool . contains (PP.pkg "hpack")) True
 
 cabal2nix' :: Options -> IO (Either Doc Derivation)


### PR DESCRIPTION
This fixes an issue when hpack is used
in combination with doJailbreak.
Before hpack run after jailbreak (preConfigure),
now it runs before (prePatch)

closes #421

Tested on [this commit](https://github.com/turboMaCk/nixpkgs/commit/7fc33f665dedef392e0ec67cdeb3a59faf57ac09) and I can confirm this resolves the issue.