### PR TITLE
Link to the YouTube video explaining hackage2nix.

### DIFF
--- a/hackage2nix/README.md
+++ b/hackage2nix/README.md
@@ -15,6 +15,9 @@ and we want to check that hackage-packages.nix will be updated correctly.
 On macOS you can use [this](https://gist.github.com/dixson3/8360571) to create one
 (you can replace 60g with 4g as that should be plenty).
 
+There is a [video on YouTube](https://www.youtube.com/watch?v=qX0mgtSm360)
+that gives a thorough walk-through of these steps.
+
 #### Setup
 Replace `git@github.com:NixOS/nixpkgs.git` with a fork you have access to.
 ```


### PR DESCRIPTION
This adds a link to the YouTube video recently released by @peti to the `hackage2nix` README.

https://discourse.nixos.org/t/video-tutorial-how-to-re-generate-the-haskell-package-set-for-nix/4074

This is a very informative video and it explains the process of running `hackage2nix` in great detail.

I think this would be very helpful for any user looking to run `hackage2nix`, or to understand how the `haskell-updates` branch is updated in nixpkgs.