### PR TITLE
Do the right thing for 32-bit android

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -136,6 +136,7 @@ ghcConvertOS os = case os of
   "watchos"       -> "ios"
   "tvos"          -> "ios"
   "linux-android" -> "linux-android"
+  "linux-androideabi" -> "linux-androideabi"
   _ | "linux-" `isPrefixOf` os -> "linux"
   _ -> fromMaybe os $ listToMaybe
     [prefix | prefix <- osPrefixes, prefix `isPrefixOf` os]


### PR DESCRIPTION
See https://github.com/haskell/cabal/pull/6301 for all the details. I'd
say it's safe to merge before the Cabal PR as the only people affected
by this bug would need to work around things anyways.

CC @kmicklas 