### PR TITLE
Fix unsafe concatenation of $LD_LIBRARY_PATH

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -255,7 +255,7 @@ gfPhaseOverrides = unlines
   , "  sed -i \"s|numJobs (bf bi)++||\" ./Setup.hs"
     -- Parallel compilation fails. Disable it.
   , "'';"
-  , "preBuild = ''export LD_LIBRARY_PATH=`pwd`/dist/build:$LD_LIBRARY_PATH'';"
+  , "preBuild = ''export LD_LIBRARY_PATH=`pwd`/dist/build''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH'';"
     -- The build step itself, after having built the library, needs to be able
     -- to find the library it just built in order to compile grammar files.
   ]


### PR DESCRIPTION
Naive concatenation of `$LD_LIBRARY_PATH` can result in an empty colon-delimited segment, which tells glibc to load libraries from the current directory.

See also NixOS/nixpkgs#76804.