### PR TITLE
[ cleanup ] don't build Agda builtins again

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -73,7 +73,8 @@ fixBuildDependsForTools = foldr (.) id
 hooks :: [(Dependency, Derivation -> Derivation)]
 hooks =
   [ ("Agda < 2.5", set (executableDepends . tool . contains (pkg "emacs")) True . set phaseOverrides agdaPostInstall)
-  , ("Agda >= 2.5", set (executableDepends . tool . contains (pkg "emacs")) True . set phaseOverrides agda25PostInstall)
+  , ("Agda >= 2.5 && < 2.6", set (executableDepends . tool . contains (pkg "emacs")) True . set phaseOverrides agda25PostInstall)
+  , ("Agda >= 2.6", set (executableDepends . tool . contains (pkg "emacs")) True)
   , ("alex < 3.1.5",  set (testDepends . tool . contains (pkg "perl")) True)
   , ("alex",  set (executableDepends . tool . contains (self "happy")) True)
   , ("alsa-core", over (metaSection . platforms) (Set.filter (\(Platform _ os) -> os == Linux)))


### PR DESCRIPTION
Since https://github.com/agda/agda/commit/378020321a223d7057cd10b59b995ebac91c7a8b, Agda's Setup.hs has contained the instructions for building the builtin modules. Thus, we do not need to do it again.

I haven't tested this yet, because building Agda requires slightly more RAM than my machine has. I can test it overnight if required, though.

/cc @abbradar 