### PR TITLE
fix fetching from remote archives

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -160,7 +160,7 @@ sourceFromHackage optHash pkgId cabalDir = do
       seq (length hash) $
       urlDerivationSource url hash <$ writeFile cacheFile hash
     UnknownHash -> do
-      maybeHash <- runMaybeT (derivHash . fst <$> fetchWith (False, "url", []) (Source url "" UnknownHash cabalDir))
+      maybeHash <- runMaybeT (derivHash . fst <$> fetchWith (False, "url", Nothing, []) (Source url "" UnknownHash cabalDir))
       case maybeHash of
         Just hash ->
           seq (length hash) $


### PR DESCRIPTION
Does what it says.
Ideally a bigger rearchitecting would have been done at the point the assumption that the kind implies the command broke down (with 854695a374862fdfe8a5881767fd17dcd39fa085), but I think that's beyond me.
Processing repositories may take longer than before if there is a big file at the same URL, since that is downloaded twice before even trying to use a version control client.
I did not add a test because I'm not sure how to do that in a way such that it can be disabled in nixpkgs (to remain in the build sandbox).
Closes #377.