### PR TITLE
extend nixpkgs update scripts to pin used versions

### DIFF
--- a/update-hackage-snapshot.sh
+++ b/update-hackage-snapshot.sh
@@ -5,12 +5,7 @@ set -eu -o pipefail
 rev=$( git ls-remote --heads git://github.com/commercialhaskell/all-cabal-hashes.git hackage \
      | cut -f1
      )
-url="https://github.com/commercialhaskell/all-cabal-hashes/archive/$rev.tar.gz"
-sha=$( nix-prefetch-url "$url" )
-
-sed -e "s|url = .*;|url = \"$url\";|"           \
-    -e "s|sha256 = .*;|sha256 = \"$sha\";|"     \
-    -i nixpkgs/pkgs/data/misc/hackage/default.nix
+nix-prefetch-github commercialhaskell all-cabal-hashes --rev "$rev" > nixpkgs/pks/data/misc/hackage/pin.json
 
 cat <<EOF
 Verify that the new snapshot actually works:

--- a/update-nixpkgs.sh
+++ b/update-nixpkgs.sh
@@ -33,8 +33,11 @@ cd ..
 # This command needs a recent development version of cabal-install. I don't
 # think this works properly in version 2.0.0.0 already.
 cabal -v0 new-run hackage2nix -- --nixpkgs="$PWD/nixpkgs" +RTS -M4G -RTS
+cabal -v0 new-run cabal2nix "https://github.com/NixOS/cabal2nix/archive/$cabal2nix.tar.gz" | sed -e 's/version = ".*"/version = "'"$(git log -1 --date=short --format=%cd)"'"/' > nixpkgs/pkgs/development/haskell-modules/cabal2nix-latest
 
 cd nixpkgs
+nix-prefetch-github commercialhaskell all-cabal-hashes --rev "$hackage" > nixpkgs/pkgs/data/misc/hackage/pin.json
+git add pkgs/data/misc/hackage
 git add pkgs/development/haskell-modules
 if [ -n "$(git status --porcelain)" ]; then
   cat <<EOF | git commit -n -q -F -


### PR DESCRIPTION
Makes sure the update scripts leave behind the necessary pins for the regenerate-hackage-packages maintainer script in nixpkgs to work.