### PR TITLE
Add tdlib to libNixName

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
@@ -153,6 +153,7 @@ libNixName "stdc++.dll"                         = [] -- What is that?
 libNixName "systemd-journal"                    = return "systemd"
 libNixName "tag_c"                              = return "taglib"
 libNixName "taglib_c"                           = return "taglib"
+libNixName "tdjson"                             = return "tdlib"
 libNixName "tensorflow"                         = return "libtensorflow"
 libNixName "udev"                               = return "systemd";
 libNixName "uuid"                               = return "libossp_uuid";


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/pull/89350

The library libtdjson is a part of tdlib.