### PR TITLE
fix bash-completion outputs

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -278,16 +278,16 @@ wxcHook drv = drv & libraryDepends . system %~ Set.union (Set.fromList [pkg "lib
 cabalInstallPostInstall :: String
 cabalInstallPostInstall = unlines
   [ "postInstall = ''"
-  , "  mkdir $out/etc"
-  , "  mv bash-completion $out/etc/bash_completion.d"
+  , "  mkdir -p $out/share/bash-completion"
+  , "  mv bash-completion $out/share/bash-completion/completions"
   , "'';"
   ]
 
 darcsInstallPostInstall :: String
 darcsInstallPostInstall = unlines
   [ "postInstall = ''"
-  , "  mkdir -p $out/etc/bash_completion.d"
-  , "  mv contrib/darcs_completion $out/etc/bash_completion.d/darcs"
+  , "  mkdir -p $out/share/bash-completion/completions"
+  , "  mv contrib/darcs_completion $out/share/bash-completion/completions/darcs"
   , "'';"
   ]
 


### PR DESCRIPTION
Use "$out/share/bash-completion/completions" because it gets
automatically loaded by the bash-completions package if "$out/share" is
listed in the XDG_DATA_DIRS environment variable.

This combined with https://github.com/NixOS/nixpkgs/pull/103501 will
mean that nix-shell environments can have completion available.