### PR TITLE
feat(FromCabal.License): don't generate unclear attributes for gpl licenses

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -18,17 +18,17 @@ import Distribution.Version
 
 fromCabalLicense :: Distribution.License.License -> Distribution.Nixpkgs.License.License
 fromCabalLicense (GPL Nothing)                             = Unknown (Just "GPL")
-fromCabalLicense (GPL (Just (versionNumbers -> [2])))      = Known "lib.licenses.gpl2"
-fromCabalLicense (GPL (Just (versionNumbers -> [3])))      = Known "lib.licenses.gpl3"
-fromCabalLicense (GPL (Just (versionNumbers -> [3,0])))    = Known "lib.licenses.gpl3"
+fromCabalLicense (GPL (Just (versionNumbers -> [2])))      = Known "lib.licenses.gpl2Only"
+fromCabalLicense (GPL (Just (versionNumbers -> [3])))      = Known "lib.licenses.gpl3Only"
+fromCabalLicense (GPL (Just (versionNumbers -> [3,0])))    = Known "lib.licenses.gpl3Only"
 fromCabalLicense (LGPL Nothing)                            = Unknown (Just "LGPL")
-fromCabalLicense (LGPL (Just (versionNumbers -> [2,1])))   = Known "lib.licenses.lgpl21"
-fromCabalLicense (LGPL (Just (versionNumbers -> [2])))     = Known "lib.licenses.lgpl2"
-fromCabalLicense (LGPL (Just (versionNumbers -> [3])))     = Known "lib.licenses.lgpl3"
-fromCabalLicense (LGPL (Just (versionNumbers -> [3,0])))   = Known "lib.licenses.lgpl3"
+fromCabalLicense (LGPL (Just (versionNumbers -> [2,1])))   = Known "lib.licenses.lgpl21Only"
+fromCabalLicense (LGPL (Just (versionNumbers -> [2])))     = Known "lib.licenses.lgpl2Only"
+fromCabalLicense (LGPL (Just (versionNumbers -> [3])))     = Known "lib.licenses.lgpl3Only"
+fromCabalLicense (LGPL (Just (versionNumbers -> [3,0])))   = Known "lib.licenses.lgpl3Only"
 fromCabalLicense (AGPL Nothing)                            = Unknown (Just "AGPL")
-fromCabalLicense (AGPL (Just (versionNumbers -> [3])))     = Known "lib.licenses.agpl3"
-fromCabalLicense (AGPL (Just (versionNumbers -> [3,0])))   = Known "lib.licenses.agpl3"
+fromCabalLicense (AGPL (Just (versionNumbers -> [3])))     = Known "lib.licenses.agpl3Only"
+fromCabalLicense (AGPL (Just (versionNumbers -> [3,0])))   = Known "lib.licenses.agpl3Only"
 fromCabalLicense (MPL (versionNumbers ->  [2,0]))          = Known "lib.licenses.mpl20"
 fromCabalLicense BSD2                                      = Known "lib.licenses.bsd2"
 fromCabalLicense BSD3                                      = Known "lib.licenses.bsd3"

--- a/test/golden-test-cases/BioHMM.nix.golden
+++ b/test/golden-test-cases/BioHMM.nix.golden
@@ -11,5 +11,5 @@ mkDerivation {
     filepath parsec ParsecTools StockholmAlignment SVGFonts text vector
   ];
   description = "Libary for Hidden Markov Models in HMMER3 format";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/bbdb.nix.golden
+++ b/test/golden-test-cases/bbdb.nix.golden
@@ -7,5 +7,5 @@ mkDerivation {
   testHaskellDepends = [ base hspec parsec ];
   homepage = "https://github.com/henrylaxen/bbdb";
   description = "Ability to read, write, and modify BBDB files";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/blosum.nix.golden
+++ b/test/golden-test-cases/blosum.nix.golden
@@ -16,5 +16,5 @@ mkDerivation {
   ];
   homepage = "http://github.com/GregorySchwartz/blosum#readme";
   description = "BLOSUM generator";
-  license = lib.licenses.gpl2;
+  license = lib.licenses.gpl2Only;
 }

--- a/test/golden-test-cases/brittany.nix.golden
+++ b/test/golden-test-cases/brittany.nix.golden
@@ -34,5 +34,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/lspitzner/brittany/";
   description = "Haskell source code formatter";
-  license = lib.licenses.agpl3;
+  license = lib.licenses.agpl3Only;
 }

--- a/test/golden-test-cases/clumpiness.nix.golden
+++ b/test/golden-test-cases/clumpiness.nix.golden
@@ -5,5 +5,5 @@ mkDerivation {
   sha256 = "deadbeef";
   libraryHaskellDepends = [ base containers tree-fun ];
   description = "Calculate the clumpiness of leaf properties in a tree";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/drawille.nix.golden
+++ b/test/golden-test-cases/drawille.nix.golden
@@ -9,5 +9,5 @@ mkDerivation {
   testHaskellDepends = [ base containers hspec QuickCheck ];
   homepage = "https://github.com/yamadapc/haskell-drawille#readme";
   description = "A port of asciimoo's drawille to haskell";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/funcmp.nix.golden
+++ b/test/golden-test-cases/funcmp.nix.golden
@@ -7,5 +7,5 @@ mkDerivation {
   libraryHaskellDepends = [ base filepath process ];
   homepage = "http://savannah.nongnu.org/projects/funcmp/";
   description = "Functional MetaPost";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/gsasl.nix.golden
+++ b/test/golden-test-cases/gsasl.nix.golden
@@ -7,5 +7,5 @@ mkDerivation {
   libraryPkgconfigDepends = [ gsasl ];
   homepage = "https://john-millikin.com/software/haskell-gsasl/";
   description = "Bindings for GNU libgsasl";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/mnist-idx.nix.golden
+++ b/test/golden-test-cases/mnist-idx.nix.golden
@@ -9,5 +9,5 @@ mkDerivation {
   testHaskellDepends = [ base binary directory hspec vector ];
   homepage = "https://github.com/kryoxide/mnist-idx/";
   description = "Read and write IDX data that is used in e.g. the MNIST database.";
-  license = lib.licenses.lgpl3;
+  license = lib.licenses.lgpl3Only;
 }

--- a/test/golden-test-cases/network-protocol-xmpp.nix.golden
+++ b/test/golden-test-cases/network-protocol-xmpp.nix.golden
@@ -11,5 +11,5 @@ mkDerivation {
   ];
   homepage = "https://john-millikin.com/software/haskell-xmpp/";
   description = "Client library for the XMPP protocol";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/once.nix.golden
+++ b/test/golden-test-cases/once.nix.golden
@@ -10,5 +10,5 @@ mkDerivation {
   ];
   homepage = "https://anonscm.debian.org/cgit/users/kaction-guest/haskell-once.git";
   description = "memoization for IO actions and functions";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/openexr-write.nix.golden
+++ b/test/golden-test-cases/openexr-write.nix.golden
@@ -12,5 +12,5 @@ mkDerivation {
   testHaskellDepends = [ base bytestring directory hspec vector ];
   homepage = "https://github.com/pavolzetor/openexr-write#readme";
   description = "Library for writing images in OpenEXR HDR file format";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }

--- a/test/golden-test-cases/tree-fun.nix.golden
+++ b/test/golden-test-cases/tree-fun.nix.golden
@@ -5,5 +5,5 @@ mkDerivation {
   sha256 = "deadbeef";
   libraryHaskellDepends = [ base containers mtl ];
   description = "Library for functions pertaining to tree exploration and manipulation";
-  license = lib.licenses.gpl3;
+  license = lib.licenses.gpl3Only;
 }


### PR DESCRIPTION
In nixpkgs, the licenses.{gpl3,gpl2,lgpl21,…} attributes are slowly
being deprecated in favor of the licenses.{gpl3Only, gpl2Only, …}
attributes which avoids confusion with the licenses.{gpl3Plus, gpl2Plus, …}
attributes. We should probably do the same as we are already doing with
the SPDX license identifiers.