### PR TITLE
FromCabal.Name: resolve library lzma to xz

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
@@ -111,6 +111,7 @@ libNixName "libxml-2.0"                         = return "libxml2"
 libNixName "libzip"                             = return "libzip"
 libNixName "libzmq"                             = return "zeromq"
 libNixName "liquid"                             = return "liquid-dsp"
+libNixName "lzma"                               = return "xz"
 libNixName "m"                                  = []  -- in stdenv
 libNixName "magic"                              = return "file"
 libNixName "MagickWand"                         = return "imagemagick"


### PR DESCRIPTION
lzma is only an alias to xz in nixpkgs nowadays which leads to all kinds
of evaluation troubles (since such aliases are stripped and not present
if aliases are disabled).

To fix this, we preemptively respect the alias in
Distribution.Nixpkgs.Haskell.FromCabal.Name.

Reference <https://github.com/nixos/nixpkgs/issues/118996>.