### PR TITLE
Improve error message when the source URI is a directory that doesn't contain a .cabal file

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -208,7 +208,7 @@ onlyCabalFromDirectory :: FilePath -> String -> MaybeT IO (Bool, Cabal.GenericPa
 onlyCabalFromDirectory dir errMsg = do
   cabals <- liftIO $ getDirectoryContents dir >>= filterM doesFileExist . map (dir </>) . filter (".cabal" `isSuffixOf`)
   case cabals of
-    [] -> fail errMsg
+    [] -> liftIO $ fail errMsg
     [cabalFile] -> (,) False <$> cabalFromFile True cabalFile
     _ -> liftIO $ fail ("*** found more than one cabal file (" ++ show cabals ++ "). Exiting.")
 


### PR DESCRIPTION
If I mistakenly pass a directory with a cabal.project file to cabal2nix-unwrapped I will get the following error message:

```
cabal2nix: nix-prefetch-url: createProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
```

This pull request makes cabal2nix report a more useful error message. Currently the `fetchLocal` fetcher in `Distribution.Nixpkgs.Fetch` fails after a check by `Distribution.Nixpkgs.Haskell.PackageSourceSpec.onlyCabalFromDirectory` but the error reporting in that function uses `fail`. In the case of `MaybeT IO a` this means that the result is `Nothing`, the `msum` in `fetch` tries the next fetcher, `nix-prefetch-url` will fail instead and the original failure will be silently dropped.

The commit modifies `onlyCabalFromDirectory` to apply `fail` in the IO monad instead (as in the `_ -> ...` case) which causes a hard fail. Other fetchers don't have to be tried because when `onlyCabalFromDirectory` is called we know that there is a directory in the filesystem so the path was originally a local directory or is the result of a successful fetch.

After this change the error message is `*** Found neither a .cabal file nor package.yaml. Exiting.` which I find less confusing.