### PR TITLE
hackage2nix: adjust to distribution-nixpkgs 1.6.0

### DIFF
--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -114,7 +114,7 @@ executable hackage2nix
                     , cabal2nix
                     , containers
                     , directory
-                    , distribution-nixpkgs >= 1.2 && < 1.6.0
+                    , distribution-nixpkgs >= 1.6
                     , filepath
                     , hopenssl             >= 2
                     , language-nix

--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -76,7 +76,7 @@ main = do
   CLI {..} <- execParser pinfo
 
   config <- sconcat <$> mapM (\file -> readConfiguration (nixpkgsRepository </> file)) configFiles
-  nixpkgs <- readNixpkgPackageMap ["-f", nixpkgsRepository, "--arg", "config", "{ allowAliases = false; }"]
+  nixpkgs <- readNixpkgPackageMap nixpkgsRepository (Just "{ config = { allowAliases = false; }; }")
   preferredVersions <- readPreferredVersions (fromMaybe (hackageRepository </> "preferred-versions") preferredVersionsFile)
   let fixup = Map.delete "acme-everything"      -- TODO: https://github.com/NixOS/cabal2nix/issues/164
             . Map.delete "som"                  -- TODO: https://github.com/NixOS/cabal2nix/issues/164


### PR DESCRIPTION
Depends on <https://github.com/peti/distribution-nixpkgs/pull/10>

If you're interested, below is a diff of running `hackage2nix` on current `haskell-updates`. Minus the noise, you can see that it actually manages to resolve some new things correctly it couldn't before which is good to see.

Only downside of this currently is that the `nixpkgs` argument must be a valid nix path, I think I'll add a format check to it, so users at least know what's going on.

<details>

```diff
diff --git a/pkgs/development/haskell-modules/hackage-packages.nix b/pkgs/development/haskell-modules/hackage-packages.nix
index 6a82b343bf9..3632dc767b7 100644
--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -12982,7 +12982,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {openmpi = null;};
+     }) {inherit (pkgs) openmpi;};
 
   "LogicGrowsOnTrees-network" = callPackage
     ({ mkDerivation, base, cereal, cmdtheline, composition, containers
@@ -41687,7 +41687,7 @@ self: {
        description = "Low level bindings to the C levmar (Levenberg-Marquardt) library";
        license = "unknown";
        hydraPlatforms = lib.platforms.none;
-     }) {inherit (pkgs) blas; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) liblapack;};
 
   "bindings-libcddb" = callPackage
     ({ mkDerivation, base, bindings-DSL, libcddb }:
@@ -58168,8 +58168,8 @@ self: {
      }:
      mkDerivation {
        pname = "code-conjure";
-       version = "0.1.2";
-       sha256 = "14xgpax596wd66kan1nj043n9f4wwn34rr77hgj6wir9aygx9sla";
+       version = "0.2.0";
+       sha256 = "0f94i5pm1rcjyldxh6pmyhp5v148qaap8vh9qm4dm00haksbgxm8";
        libraryHaskellDepends = [
          base express leancheck speculate template-haskell
        ];
@@ -65202,7 +65202,7 @@ self: {
        license = lib.licenses.gpl3Only;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {python3 = null;};
+     }) {inherit (pkgs) python3;};
 
   "cql" = callPackage
     ({ mkDerivation, base, bytestring, cereal, containers, Decimal
@@ -78281,6 +78281,32 @@ self: {
        license = lib.licenses.bsd3;
      }) {};
 
+  "do-spaces" = callPackage
+    ({ mkDerivation, base, base16-bytestring, bytestring
+     , case-insensitive, conduit, conduit-extra, config-ini, containers
+     , cryptonite, exceptions, extra, filepath, generic-lens, hspec
+     , http-client-tls, http-conduit, http-types, memory, microlens
+     , mime-types, mtl, resourcet, text, time, transformers, xml-conduit
+     }:
+     mkDerivation {
+       pname = "do-spaces";
+       version = "0.1.0";
+       sha256 = "1xj0n2pmmwkm4ss5gvsbvw8m545w4890a3hhk1ns1vbbm06zmvsi";
+       libraryHaskellDepends = [
+         base base16-bytestring bytestring case-insensitive conduit
+         conduit-extra config-ini containers cryptonite exceptions extra
+         filepath generic-lens http-client-tls http-conduit http-types
+         memory microlens mime-types mtl text time transformers xml-conduit
+       ];
+       testHaskellDepends = [
+         base bytestring case-insensitive conduit conduit-extra containers
+         generic-lens hspec http-client-tls http-conduit http-types
+         microlens mtl resourcet text time
+       ];
+       description = "DigitalOcean Spaces API bindings";
+       license = lib.licenses.bsd3;
+     }) {};
+
   "dobutok" = callPackage
     ({ mkDerivation, base }:
      mkDerivation {
@@ -104386,7 +104412,7 @@ self: {
        license = lib.licenses.lgpl21Only;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {gtk-mac-integration-gtk3 = null;};
+     }) {inherit (pkgs) gtk-mac-integration-gtk3;};
 
   "gi-gtksheet" = callPackage
     ({ mkDerivation, base, bytestring, Cabal, containers, gi-atk
@@ -113586,7 +113612,7 @@ self: {
        license = lib.licenses.lgpl21Only;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {gtk-mac-integration-gtk3 = null;};
+     }) {inherit (pkgs) gtk-mac-integration-gtk3;};
 
   "gtkglext" = callPackage
     ({ mkDerivation, base, Cabal, glib, gtk, gtk2, gtk2hs-buildtools
@@ -114386,7 +114412,7 @@ self: {
        license = "GPL";
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {inherit (pkgs) blas; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) liblapack;};
 
   "hXmixer" = callPackage
     ({ mkDerivation, base, directory, gtk3, process, split, text }:
@@ -118689,8 +118715,8 @@ self: {
      }:
      mkDerivation {
        pname = "hascard";
-       version = "0.5.0.1";
-       sha256 = "08j3bi6a04pkkf99ghw2h7z1bdisby0d3hyqv559a1pxwpbi7k22";
+       version = "0.5.0.2";
+       sha256 = "1sh4903x05fwci7nmlqd0f2wjjs5b9bqckmgrkjpnawcnsbby1ds";
        isLibrary = true;
        isExecutable = true;
        libraryHaskellDepends = [
@@ -120487,7 +120513,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {open-pal = null; open-rte = null; openmpi = null;};
+     }) {open-pal = null; open-rte = null; inherit (pkgs) openmpi;};
 
   "haskell-names" = callPackage
     ({ mkDerivation, aeson, base, bytestring, containers
@@ -124728,7 +124754,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {inherit (pkgs) blas; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) liblapack;};
 
   "hblock" = callPackage
     ({ mkDerivation, aeson, base, blaze-markup, bytestring, cereal
@@ -124916,29 +124942,31 @@ self: {
   "hcheckers" = callPackage
     ({ mkDerivation, aeson, array, base, binary, bits, bytes
      , bytestring, clock, concurrent-extra, containers, data-default
-     , directory, ekg, ekg-core, exceptions, fast-logger, filepath
-     , hashable, hashtables, heavy-logger, hsyslog, http-types
-     , megaparsec, microlens, monad-metrics, mtl, mwc-random, network
-     , optparse-applicative, psqueues, random, random-access-file
-     , random-shuffle, scotty, stm, stm-containers, store
-     , template-haskell, text, text-format-heavy, unix, unix-bytestring
-     , unordered-containers, vector, wai, warp, yaml
+     , directory, ekg, ekg-core, exceptions, fast-logger, filepath, Glob
+     , hashable, hashtables, heavy-logger, hsyslog, http-types, list-t
+     , megaparsec, microlens, modern-uri, monad-metrics, mtl, mwc-random
+     , network, optparse-applicative, psqueues, random
+     , random-access-file, random-shuffle, req, scotty, stm
+     , stm-containers, store, template-haskell, text, text-format-heavy
+     , unix, unix-bytestring, unordered-containers, vector, wai, warp
+     , yaml
      }:
      mkDerivation {
        pname = "hcheckers";
-       version = "0.1.0.1";
-       sha256 = "1l4cj7v4scnz5cq05294ym4gyv163ry09bpxp1vg1m1v88ww5i2w";
+       version = "0.1.0.2";
+       sha256 = "1v4hnqvi47kn10c1rjgsggxmajy7xnl462ghb2fs61ksbmrdi5b8";
        isLibrary = false;
        isExecutable = true;
        executableHaskellDepends = [
          aeson array base binary bits bytes bytestring clock
          concurrent-extra containers data-default directory ekg ekg-core
-         exceptions fast-logger filepath hashable hashtables heavy-logger
-         hsyslog http-types megaparsec microlens monad-metrics mtl
-         mwc-random network optparse-applicative psqueues random
-         random-access-file random-shuffle scotty stm stm-containers store
-         template-haskell text text-format-heavy unix unix-bytestring
-         unordered-containers vector wai warp yaml
+         exceptions fast-logger filepath Glob hashable hashtables
+         heavy-logger hsyslog http-types list-t megaparsec microlens
+         modern-uri monad-metrics mtl mwc-random network
+         optparse-applicative psqueues random random-access-file
+         random-shuffle req scotty stm stm-containers store template-haskell
+         text text-format-heavy unix unix-bytestring unordered-containers
+         vector wai warp yaml
        ];
        description = "Implementation of checkers (\"draughts\") board game - server application";
        license = lib.licenses.bsd3;
@@ -131552,9 +131580,7 @@ self: {
        testHaskellDepends = [ base bytestring hls-test-utils text ];
        description = "Integration with the Brittany code formatter";
        license = lib.licenses.asl20;
-       hydraPlatforms = lib.platforms.none;
-       broken = true;
-     }) {hls-test-utils = null;};
+     }) {};
 
   "hls-class-plugin" = callPackage
     ({ mkDerivation, aeson, base, containers, ghc, ghc-exactprint
@@ -131818,6 +131844,28 @@ self: {
        license = lib.licenses.asl20;
      }) {};
 
+  "hls-test-utils" = callPackage
+    ({ mkDerivation, aeson, async, base, blaze-markup, bytestring
+     , containers, data-default, directory, extra, filepath, ghcide
+     , hls-plugin-api, hspec, hspec-core, lens, lsp, lsp-test, lsp-types
+     , shake, tasty, tasty-expected-failure, tasty-golden, tasty-hunit
+     , tasty-rerun, temporary, text, unordered-containers
+     }:
+     mkDerivation {
+       pname = "hls-test-utils";
+       version = "1.0.0.0";
+       sha256 = "18n7vb9fa39jkgr0gvsrjfc0nh09w2xlniifb25bn6z3qc3w0h6i";
+       libraryHaskellDepends = [
+         aeson async base blaze-markup bytestring containers data-default
+         directory extra filepath ghcide hls-plugin-api hspec hspec-core
+         lens lsp lsp-test lsp-types shake tasty tasty-expected-failure
+         tasty-golden tasty-hunit tasty-rerun temporary text
+         unordered-containers
+       ];
+       description = "Utilities used in the tests of Haskell Language Server";
+       license = lib.licenses.asl20;
+     }) {};
+
   "hlwm" = callPackage
     ({ mkDerivation, base, stm, transformers, unix, X11 }:
      mkDerivation {
@@ -131941,7 +131989,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {liblapack = null;};
+     }) {inherit (pkgs) liblapack;};
 
   "hmatrix-csv" = callPackage
     ({ mkDerivation, base, bytestring, cassava, hmatrix, vector }:
@@ -132028,7 +132076,7 @@ self: {
        benchmarkHaskellDepends = [ base criterion hmatrix ];
        description = "Low-level machine learning auxiliary functions";
        license = lib.licenses.bsd3;
-     }) {inherit (pkgs) blas; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) liblapack;};
 
   "hmatrix-nipals" = callPackage
     ({ mkDerivation, base, hmatrix }:
@@ -137973,7 +138021,8 @@ self: {
        libraryPkgconfigDepends = [ gsl ];
        description = "Signal processing and EEG data analysis";
        license = lib.licenses.bsd3;
-     }) {inherit (pkgs) blas; inherit (pkgs) gsl; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) gsl; 
+         inherit (pkgs) liblapack;};
 
   "hsilop" = callPackage
     ({ mkDerivation, base, directory, filepath, haskeline, xdg-basedir
@@ -148854,6 +148903,8 @@ self: {
        pname = "inline-java";
        version = "0.10.0";
        sha256 = "0rs2rw21y0yc0h4c1rz25qblk39flkg19fwjz87s6l0ly1hvcrm5";
+       revision = "1";
+       editedCabalFile = "07qpgqy66zpmg1yz38y1w5gbbcc0nvidmlg2z4anj0k5rifzgdv6";
        libraryHaskellDepends = [
          base bytestring Cabal directory filepath ghc jni jvm language-java
          mtl process template-haskell temporary text
@@ -149917,8 +149968,8 @@ self: {
      }:
      mkDerivation {
        pname = "interval-algebra";
-       version = "0.5.0";
-       sha256 = "1zjqyhcdi058gkq8pyhwfnn2zlzj8iifsl2c1z2ngvmpgxivq0qc";
+       version = "0.6.1";
+       sha256 = "1kdifqjgvlzg8mmphqbbhyd0qhmm0wgjk0f77xd1sg2wn968q4x5";
        libraryHaskellDepends = [
          base containers QuickCheck time witherable
        ];
@@ -150675,6 +150726,23 @@ self: {
        license = lib.licenses.bsd3;
      }) {};
 
+  "ipa_0_3_1" = callPackage
+    ({ mkDerivation, attoparsec, base, hspec, template-haskell, text
+     , unicode-transforms
+     }:
+     mkDerivation {
+       pname = "ipa";
+       version = "0.3.1";
+       sha256 = "1l658qnqfs63dwarmiaw7vf6v2xl8hhvzlb95w168rpa7wfkrh5n";
+       libraryHaskellDepends = [
+         attoparsec base template-haskell text unicode-transforms
+       ];
+       testHaskellDepends = [ base hspec text ];
+       description = "Internal Phonetic Alphabet (IPA)";
+       license = lib.licenses.bsd3;
+       hydraPlatforms = lib.platforms.none;
+     }) {};
+
   "ipatch" = callPackage
     ({ mkDerivation, base, bytestring, darcs, directory, filepath
      , hashed-storage, process, unix
@@ -153215,6 +153283,8 @@ self: {
        pname = "jni";
        version = "0.8.0";
        sha256 = "0m94p2zx877snh3imwcdnwa8ajfb76cg2rjgjx3pan508ham1h5i";
+       revision = "2";
+       editedCabalFile = "1ql65nfmd5mhn7y2xdifx240mk5my5z8w3pn85497hzk27qllybi";
        libraryHaskellDepends = [
          async base bytestring choice constraints containers deepseq
          inline-c singletons stm text
@@ -154209,7 +154279,7 @@ self: {
        license = lib.licenses.mit;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {python = null;};
+     }) {inherit (pkgs) python;};
 
   "json-qq" = callPackage
     ({ mkDerivation, base, haskell-src-meta, parsec, template-haskell
@@ -155199,6 +155269,8 @@ self: {
        pname = "jvm";
        version = "0.6.0";
        sha256 = "119davscv5mrw2mnlrklx8hbjrc7lhf5a9jphdnnxs6bywi8i2zm";
+       revision = "2";
+       editedCabalFile = "1p0p50w0zjf79a3p5wiwg1wfnsgvqf2n04ydpacrfwm96id667kp";
        libraryHaskellDepends = [
          base bytestring choice constraints distributed-closure exceptions
          jni singletons template-haskell text vector
@@ -155224,6 +155296,8 @@ self: {
        pname = "jvm-batching";
        version = "0.2.0";
        sha256 = "19z0db10y181n4adkz23cmly0q4zp953zh6f3r7rmxcd78758pbk";
+       revision = "1";
+       editedCabalFile = "1ni0gnww6r18dg2pm1hmdkfzaghq5ssirpp737i1c81ya1k95m2n";
        setupHaskellDepends = [ base Cabal inline-java ];
        libraryHaskellDepends = [
          base bytestring distributed-closure inline-java jni jvm singletons
@@ -155302,6 +155376,8 @@ self: {
        pname = "jvm-streaming";
        version = "0.4.0";
        sha256 = "0k8y6kvbymmjlr3bvgcws0z2hwdznyr3b3alkwsjag49lsgp21sd";
+       revision = "1";
+       editedCabalFile = "01f3j02qzqi7ls876vwzl2db3621xr7psmzm3cx9pk414bhj5f56";
        setupHaskellDepends = [ base Cabal inline-java jvm-batching ];
        libraryHaskellDepends = [
          base distributed-closure inline-java jni jvm jvm-batching
@@ -160607,7 +160683,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {liblapack = null;};
+     }) {inherit (pkgs) liblapack;};
 
   "lapack-ffi-tools" = callPackage
     ({ mkDerivation, base, bytestring, cassava, containers
@@ -195620,7 +195696,7 @@ self: {
        platforms = [
          "aarch64-linux" "armv7l-linux" "i686-linux" "x86_64-linux"
        ];
-     }) {pam = null;};
+     }) {inherit (pkgs) pam;};
 
   "pan-os-syslog" = callPackage
     ({ mkDerivation, base, byteslice, bytesmith, chronos, gauge, ip
@@ -200796,6 +200872,8 @@ self: {
        pname = "persistent-mongoDB";
        version = "2.12.0.0";
        sha256 = "1s49d4c4kiqcblkap96wcrp3nc0179vpzbqp4fdibljq9ylzxmzg";
+       revision = "1";
+       editedCabalFile = "047riy3grn68jw99095qgqxvfs5bvxmcvmnz170nrqflrlr4l4dd";
        libraryHaskellDepends = [
          aeson base bson bytestring cereal conduit http-api-data mongoDB
          network path-pieces persistent resource-pool resourcet text time
@@ -201780,8 +201858,8 @@ self: {
     ({ mkDerivation, base, containers, gu, pgf, pretty }:
      mkDerivation {
        pname = "pgf2";
-       version = "1.2.1";
-       sha256 = "10nbwhdirhlsh68f14z8y75wlbs9f9xcn8cbgkf47m74x71jqqb3";
+       version = "1.3.0";
+       sha256 = "1sd21p6f9m9l6xnf853v7lxj6j6sbsrd7i09y0w0lsysp86p8h7m";
        libraryHaskellDepends = [ base containers pretty ];
        librarySystemDepends = [ gu pgf ];
        description = "Bindings to the C version of the PGF runtime";
@@ -202184,8 +202262,8 @@ self: {
      }:
      mkDerivation {
        pname = "phonetic-languages-phonetics-basics";
-       version = "0.5.1.0";
-       sha256 = "1pqc16llr1ar7z6lfbniinxx7q09qpamajmbl3d9njhk4pwdl6b8";
+       version = "0.6.0.1";
+       sha256 = "1bf7q44qksna66mgsycb2hqg3vb30zd4x7403ffapzbzm0n44wnj";
        isLibrary = true;
        isExecutable = true;
        libraryHaskellDepends = [
@@ -214440,7 +214518,7 @@ self: {
        license = lib.licenses.mit;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {python = null;};
+     }) {inherit (pkgs) python;};
 
   "pyfi" = callPackage
     ({ mkDerivation, aeson, base, bytestring, containers, pureMD5
@@ -214458,7 +214536,7 @@ self: {
        license = lib.licenses.mit;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {python = null;};
+     }) {inherit (pkgs) python;};
 
   "python-pickle" = callPackage
     ({ mkDerivation, attoparsec, base, bytestring, cereal, cmdargs
@@ -220002,7 +220080,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {raptor2 = null; redland = null;};
+     }) {raptor2 = null; inherit (pkgs) redland;};
 
   "redo" = callPackage
     ({ mkDerivation, base, bytestring, containers, directory, filepath
@@ -245067,6 +245145,8 @@ self: {
        pname = "sparkle";
        version = "0.7.4";
        sha256 = "174rs21fgj43rq3nshzgff6mydi93n26nkcq9cadq0bzcasc2n3q";
+       revision = "1";
+       editedCabalFile = "1jwg12rmsa1il8y53ip535bjf02z7jnrnws1qi9y0xfpqblzmw6r";
        isLibrary = true;
        isExecutable = true;
        setupHaskellDepends = [ base Cabal inline-java jvm-streaming ];
```

</details>