### PR TITLE
WIP: platform handling refactors

### DIFF
--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -114,7 +114,7 @@ executable hackage2nix
                     , cabal2nix
                     , containers
                     , directory
-                    , distribution-nixpkgs >= 1.2
+                    , distribution-nixpkgs >= 1.6
                     , filepath
                     , hopenssl             >= 2
                     , language-nix

--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -145,9 +145,6 @@ main = do
           isHydraEnabled = isInDefaultPackageSet && not (isBroken || name `Set.member` dontDistributePackages config)
           isBroken = any (withinRange v) [ vr | PackageVersionConstraint pn vr <- brokenPackages config, pn == name ]
 
-          droppedPlatforms :: Set Platform
-          droppedPlatforms = Map.findWithDefault mempty name (unsupportedPlatforms config)
-
           tarballSHA256 :: SHA256Hash
           tarballSHA256 = fromMaybe (error (display pkgId ++ ": meta data has no hash for the tarball"))
                                     (view (hashes . at "SHA256") meta)
@@ -162,9 +159,8 @@ main = do
           drv = fromGenericPackageDescription haskellResolver nixpkgsResolver targetPlatform (compilerInfo config) flagAssignment [] descr
                   & src .~ urlDerivationSource ("mirror://hackage/" ++ display pkgId ++ ".tar.gz") tarballSHA256
                   & editedCabalFile .~ cabalSHA256
-                  & metaSection.platforms %~ (`Set.difference` Map.findWithDefault Set.empty name (unsupportedPlatforms config))
-                  & metaSection.hydraPlatforms %~ (if Set.null droppedPlatforms then id else (`Set.difference` droppedPlatforms))
-                  & metaSection.hydraPlatforms %~ (if isHydraEnabled then id else const Set.empty)
+                  & metaSection.badPlatforms .~ fmap (Set.map Right) (Map.lookup name (unsupportedPlatforms config))
+                  & metaSection.hydraPlatforms %~ (if isHydraEnabled then id else const (Just Set.empty))
                   & metaSection.broken ||~ isBroken
                   & metaSection.maintainers .~ Map.findWithDefault Set.empty name globalPackageMaintainers
                   & metaSection.homepage .~ ""

--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -76,7 +76,7 @@ main = do
   CLI {..} <- execParser pinfo
 
   config <- sconcat <$> mapM (\file -> readConfiguration (nixpkgsRepository </> file)) configFiles
-  nixpkgs <- readNixpkgPackageMap ["-f", nixpkgsRepository, "--arg", "config", "{ allowAliases = false; }"]
+  nixpkgs <- readNixpkgPackageMap nixpkgsRepository (Just "{ config = { allowAliases = false; }; }")
   preferredVersions <- readPreferredVersions (fromMaybe (hackageRepository </> "preferred-versions") preferredVersionsFile)
   let fixup = Map.delete "acme-everything"      -- TODO: https://github.com/NixOS/cabal2nix/issues/164
             . Map.delete "som"                  -- TODO: https://github.com/NixOS/cabal2nix/issues/164

--- a/src/Distribution/Nixpkgs/Haskell/Derivation.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Derivation.hs
@@ -110,7 +110,7 @@ instance Package Derivation where
 instance NFData Derivation
 
 instance Pretty Derivation where
-  pPrint drv@MkDerivation {..} = funargs (map text ("mkDerivation" : toAscList inputs)) $$ vcat
+  pPrint drv@MkDerivation {..} = funargs (map text ("mkDerivation" : toCaseInsensitiveAscList inputs)) $$ vcat
     [ text "mkDerivation" <+> lbrace
     , nest 2 $ vcat
       [ attr "pname"   $ doubleQuotes $ pPrint (packageName _pkgid)
@@ -151,7 +151,7 @@ instance Pretty Derivation where
                           ]
 
       renderedFlags = [ text "-f" <> (if enable then empty else char '-') <> text (unFlagName f) | (f, enable) <- unFlagAssignment _cabalFlags ]
-                      ++ map text (toAscList _configureFlags)
+                      ++ map text (Set.toAscList _configureFlags)
       isHackagePackage = "mirror://hackage/" `isPrefixOf` derivUrl _src
 
       postUnpack = string $ "sourceRoot+=/" ++ _subpath ++ "; echo source root reset to $sourceRoot"

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -132,8 +132,8 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
                      & Nix.description .~ stripRedundanceSpaces synopsis
 #endif
                      & Nix.license .~ nixLicense
-                     & Nix.platforms .~ Nix.allKnownPlatforms
-                     & Nix.hydraPlatforms .~ (if isFreeLicense nixLicense then Nix.allKnownPlatforms else Set.empty)
+                     & Nix.platforms .~ Nothing
+                     & Nix.hydraPlatforms .~ (if isFreeLicense nixLicense then Nothing else Just Set.empty)
                      & Nix.maintainers .~ mempty
                      & Nix.broken .~ not (null missingDeps)
                      )

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Normalize.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Normalize.hs
@@ -27,8 +27,7 @@ normalizeBuildInfo pname bi = bi
 normalizeMeta :: Meta -> Meta
 normalizeMeta meta = meta
   & description %~ normalizeSynopsis
-  & platforms %~ Set.intersection allKnownPlatforms
-  & hydraPlatforms %~ (if meta^.broken then const Set.empty else Set.intersection (meta^.platforms))
+  & hydraPlatforms %~ (if meta^.broken then const (Just Set.empty) else id)
 
 normalizeSynopsis :: String -> String
 normalizeSynopsis desc

--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -15,7 +15,6 @@ import Distribution.Nixpkgs.Haskell
 import Distribution.Nixpkgs.Meta
 import Distribution.Nixpkgs.License
 import Distribution.Package
-import Distribution.System
 import Distribution.Types.PackageVersionConstraint
 import Distribution.Text
 import Distribution.Version
@@ -78,9 +77,9 @@ hooks =
   , ("Agda >= 2.6", set (executableDepends . tool . contains (pkg "emacs")) True)
   , ("alex < 3.1.5",  set (testDepends . tool . contains (pkg "perl")) True)
   , ("alex",  set (executableDepends . tool . contains (self "happy")) True)
-  , ("alsa-core", over (metaSection . platforms) (Set.filter (\(Platform _ os) -> os == Linux)))
+  , ("alsa-core", set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "linux"))))
   , ("bindings-GLFW", over (libraryDepends . system) (Set.union (Set.fromList [bind "pkgs.xorg.libXext", bind "pkgs.xorg.libXfixes"])))
-  , ("bindings-lxc", over (metaSection . platforms) (Set.filter (\(Platform _ os) -> os == Linux)))
+  , ("bindings-lxc", set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "linux"))))
   , ("bustle", bustleOverrides)
   , ("Cabal", set doCheck False) -- test suite doesn't work in Nix
   , ("Cabal >2.2", over (setupDepends . haskell) (Set.union (Set.fromList [self "mtl", self "parsec"]))) -- https://github.com/haskell/cabal/issues/5391
@@ -91,7 +90,7 @@ hooks =
   , ("dbus", set doCheck False) -- don't execute tests that try to access the network
   , ("dhall", set doCheck False) -- attempts to access the network
   , ("dns", set testTarget "spec")      -- don't execute tests that try to access the network
-  , ("eventstore", over (metaSection . platforms) (Set.filter (\(Platform arch _) -> arch == X86_64)))
+  , ("eventstore", set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "x86_64"))))
   , ("freenect < 1.2.1", over configureFlags (Set.union (Set.fromList ["--extra-include-dirs=${pkgs.freenect}/include/libfreenect", "--extra-lib-dirs=${pkgs.freenect}/lib"])))
   , ("fltkhs", set (libraryDepends . system . contains (pkg "fltk14")) True . over (libraryDepends . pkgconfig) (Set.union (pkgs ["libGLU", "libGL"]))) -- TODO: fltk14 belongs into the *setup* dependencies.
   , ("gf", set phaseOverrides gfPhaseOverrides . set doCheck False)
@@ -144,7 +143,7 @@ hooks =
   , ("libxml", set (configureFlags . contains "--extra-include-dir=${libxml2.dev}/include/libxml2") True)
   , ("liquid-fixpoint", set (executableDepends . system . contains (pkg "ocaml")) True . set (testDepends . system . contains (pkg "z3")) True . set (testDepends . system . contains (pkg "nettools")) True . set (testDepends . system . contains (pkg "git")) True . set doCheck False)
   , ("liquidhaskell", set (testDepends . system . contains (pkg "z3")) True)
-  , ("lzma-clib", over (metaSection . platforms) (Set.filter (\(Platform _  os) -> os == Windows)) . set (libraryDepends . haskell . contains (self "only-buildable-on-windows")) False)
+  , ("lzma-clib", set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "windows"))) . set (libraryDepends . haskell . contains (self "only-buildable-on-windows")) False)
   , ("MFlow < 4.6", set (libraryDepends . tool . contains (self "cpphs")) True)
   , ("mwc-random", set doCheck False)
   , ("mysql", set (libraryDepends . system . contains (pkg "libmysqlclient")) True)
@@ -163,7 +162,7 @@ hooks =
   , ("readline", over (libraryDepends . system) (Set.union (pkgs ["readline", "ncurses"])))
   , ("req", set doCheck False)  -- test suite requires network access
   , ("sbv > 7", set (testDepends . system . contains (pkg "z3")) True)
-  , ("sdr", over (metaSection . platforms) (Set.filter (\(Platform arch _) -> arch == X86_64))) -- https://github.com/adamwalker/sdr/issues/2
+  , ("sdr", set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "x86_64")))) -- https://github.com/adamwalker/sdr/issues/2
   , ("shake-language-c", set doCheck False) -- https://github.com/samplecount/shake-language-c/issues/26
   , ("ssh", set doCheck False) -- test suite runs forever, probably can't deal with our lack of network access
   , ("stack", set phaseOverrides stackOverrides . set doCheck False)
@@ -175,12 +174,12 @@ hooks =
   , ("thyme", set (libraryDepends . tool . contains (self "cpphs")) True) -- required on Darwin
   , ("twilio", set doCheck False)         -- attempts to access the network
   , ("tz", set phaseOverrides "preConfigure = \"export TZDIR=${pkgs.tzdata}/share/zoneinfo\";")
-  , ("udev", over (metaSection . platforms) (Set.filter (\(Platform _ os) -> os == Linux)))
+  , ("udev", set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "linux"))))
   , ("webkitgtk3", webkitgtk24xHook)   -- https://github.com/haskell-gi/haskell-gi/issues/36
   , ("webkitgtk3-javascriptcore", webkitgtk24xHook)   -- https://github.com/haskell-gi/haskell-gi/issues/36
   , ("websockets", set doCheck False)   -- https://github.com/jaspervdj/websockets/issues/104
-  , ("Win32", over (metaSection . platforms) (Set.filter (\(Platform _ os) -> os == Windows)))
-  , ("Win32-shortcut", over (metaSection . platforms) (Set.filter (\(Platform _ os) -> os == Windows)))
+  , ("Win32", set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "windows"))))
+  , ("Win32-shortcut", set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "windows"))))
   , ("wxc", wxcHook)
   , ("wxcore", set (libraryDepends . pkgconfig . contains (pkg "wxGTK")) True)
   , ("X11", over (libraryDepends . system) (Set.union (Set.fromList $ map bind ["pkgs.xorg.libXinerama","pkgs.xorg.libXext","pkgs.xorg.libXrender","pkgs.xorg.libXScrnSaver"])))
@@ -351,7 +350,7 @@ giCairoPhaseOverrides = over phaseOverrides (++txt)
 hfseventsOverrides :: Derivation -> Derivation
 hfseventsOverrides
   = set isLibrary True
-  . over (metaSection . platforms) (Set.filter (\(Platform _ os) -> os == OSX))
+  . set (metaSection . platforms) (Just $ Set.singleton (Left (ident # "darwin")))
   . set (libraryDepends . tool . contains (bind "pkgs.darwin.apple_sdk.frameworks.CoreServices")) True
   . set (libraryDepends . system . contains (bind "pkgs.darwin.apple_sdk.frameworks.Cocoa")) True
   . over (libraryDepends . haskell) (Set.union (Set.fromList (map bind ["self.base", "self.cereal", "self.mtl", "self.text", "self.bytestring"])))
@@ -409,7 +408,7 @@ bustleOverrides :: Derivation -> Derivation
 bustleOverrides = set (libraryDepends . pkgconfig . contains "system-glib = pkgs.glib") True
                 . set (executableDepends . pkgconfig . contains "gio-unix = null") False
                 . set (metaSection . license) (Known "lib.licenses.lgpl21Plus")
-                . set (metaSection . hydraPlatforms) allKnownPlatforms
+                . set (metaSection . hydraPlatforms) Nothing
 
 nullBinding :: Identifier -> Binding
 nullBinding name = binding # (name, path # [ident # "null"])


### PR DESCRIPTION
Mostly using the new stuff in <https://github.com/peti/distribution-nixpkgs/pull/13>:

* Emit `badPlatforms` instead of subtracting from `allKnownPlatforms`
* Use `lib.platforms.{linux,windows,darwin}` in `PostProcess.hs` instead of filtering `allKnownPlatforms`