### PR TITLE
Distribution.Nixpkgs.Haskell.OrphanInstances: parse `aarch64-darwin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Only use `hpack` when building if no cabal file is found
   for the package to process
   (See [#508](https://github.com/NixOS/cabal2nix/pull/508))
+* Support `aarch64-darwin` as an unsupported platform in
+  `hackage2nix` (See [#517](https://github.com/NixOS/cabal2nix/pull/517))
 
 ## 2.18.0
 

--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -56,7 +56,7 @@ library
                     , containers           >= 0.5.9
                     , deepseq              >= 1.4
                     , directory
-                    , distribution-nixpkgs >= 1.5.0
+                    , distribution-nixpkgs >= 1.6.1
                     , filepath
                     , hackage-db           >= 2.0.1
                     , hopenssl             >= 2

--- a/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
+++ b/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
@@ -40,6 +40,7 @@ instance IsString Platform where
   fromString "x86_64-linux" = Platform X86_64 Linux
   fromString "x86_64-darwin" = Platform X86_64 OSX
   fromString "aarch64-linux" = Platform AArch64 Linux
+  fromString "aarch64-darwin" = Platform AArch64 OSX
   fromString "armv7l-linux" = Platform (OtherArch "armv7l") Linux
   fromString s = error ("fromString: " ++ show s ++ " is not a valid platform")
 


### PR DESCRIPTION
To support `aarch64-darwin` in the `unsupported-platforms`
configuration, we need to correctly parse it in the `FromJSON` instance
of `Platform`.

We increase the lower bound on `distribution-nixpkgs` in order to
prevent users from being able to parse a configuration which will
result in `hackage2nix` crashing while rendering the resulting nix
file (`aarch64-darwin` support was added to distribution-nixpkgs in
version 1.6.1).