### PR TITLE
cabal2nix: Assume "unknown" hackage license to be free

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -163,7 +163,17 @@ fromSPDXLicense (SPDX.License expr) =
       -- Use the SPDX expression as a free-form license string.
       Unknown (Just $ prettyShow expr)
 
+-- "isFreeLicense" is used to determine whether we generate a "hydraPlatforms =
+-- none" in the hackage2nix output for a package with the given license.
+
+-- Note: If "isFreeLicense" returned false for a license which is not an unfree
+-- license from "lib.licenses" the package would still be build by hydra if
+-- another package depended on it.
+
+-- Since all software on hackage needs to be "open source in spirit" and we
+-- don‘t know any software on hackage for which we are not allowed to
+-- distribute binary outputs we assume that a package has a free license if we
+-- don‘t explicitly know otherwise.
 isFreeLicense :: Distribution.Nixpkgs.License.License -> Bool
 isFreeLicense (Known "lib.licenses.unfree") = False
-isFreeLicense (Unknown Nothing)             = False
 isFreeLicense _                             = True

--- a/test/golden-test-cases/ede.nix.golden
+++ b/test/golden-test-cases/ede.nix.golden
@@ -21,5 +21,4 @@ mkDerivation {
   homepage = "http://github.com/brendanhay/ede";
   description = "Templating language with similar syntax and features to Liquid or Jinja2";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-adexchange-buyer.nix.golden
+++ b/test/golden-test-cases/gogol-adexchange-buyer.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Ad Exchange Buyer SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-admin-emailmigration.nix.golden
+++ b/test/golden-test-cases/gogol-admin-emailmigration.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Email Migration API v2 SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-affiliates.nix.golden
+++ b/test/golden-test-cases/gogol-affiliates.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Affiliate Network SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-apps-tasks.nix.golden
+++ b/test/golden-test-cases/gogol-apps-tasks.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Tasks SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-appstate.nix.golden
+++ b/test/golden-test-cases/gogol-appstate.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google App State SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-blogger.nix.golden
+++ b/test/golden-test-cases/gogol-blogger.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Blogger SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-datastore.nix.golden
+++ b/test/golden-test-cases/gogol-datastore.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Cloud Datastore SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-dfareporting.nix.golden
+++ b/test/golden-test-cases/gogol-dfareporting.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google DCM/DFA Reporting And Trafficking SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-firebase-rules.nix.golden
+++ b/test/golden-test-cases/gogol-firebase-rules.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Firebase Rules SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-gmail.nix.golden
+++ b/test/golden-test-cases/gogol-gmail.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Gmail SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-kgsearch.nix.golden
+++ b/test/golden-test-cases/gogol-kgsearch.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Knowledge Graph Search SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-maps-engine.nix.golden
+++ b/test/golden-test-cases/gogol-maps-engine.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Maps Engine SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-plus.nix.golden
+++ b/test/golden-test-cases/gogol-plus.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google + SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-resourceviews.nix.golden
+++ b/test/golden-test-cases/gogol-resourceviews.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Compute Engine Instance Groups SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-translate.nix.golden
+++ b/test/golden-test-cases/gogol-translate.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Translate SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-webmaster-tools.nix.golden
+++ b/test/golden-test-cases/gogol-webmaster-tools.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Search Console SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/gogol-youtube.nix.golden
+++ b/test/golden-test-cases/gogol-youtube.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google YouTube Data SDK";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/hxt-expat.nix.golden
+++ b/test/golden-test-cases/hxt-expat.nix.golden
@@ -7,5 +7,4 @@ mkDerivation {
   homepage = "http://www.fh-wedel.de/~si/HXmlToolbox/index.html";
   description = "Expat parser for HXT";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/hxt-tagsoup.nix.golden
+++ b/test/golden-test-cases/hxt-tagsoup.nix.golden
@@ -11,5 +11,4 @@ mkDerivation {
   homepage = "https://github.com/UweSchmidt/hxt";
   description = "TagSoup parser for HXT";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/openpgp-asciiarmor.nix.golden
+++ b/test/golden-test-cases/openpgp-asciiarmor.nix.golden
@@ -15,5 +15,4 @@ mkDerivation {
   homepage = "http://floss.scru.org/openpgp-asciiarmor";
   description = "OpenPGP (RFC4880) ASCII Armor codec";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }

--- a/test/golden-test-cases/swagger.nix.golden
+++ b/test/golden-test-cases/swagger.nix.golden
@@ -11,5 +11,4 @@ mkDerivation {
   testHaskellDepends = [ aeson base bytestring tasty tasty-hunit ];
   description = "Implementation of swagger data model";
   license = "unknown";
-  hydraPlatforms = lib.platforms.none;
 }


### PR DESCRIPTION
We are currently very inconsequent in regard to "unknown" licenses. In
general they stem from packages having their license field set to
"LicenseRef-OtherLicense" accompanied by a LICENSE file which specifies
the real license.

Currently in nixpkgs "unknown" licenses result in hydra builds being
disabled for that package, but the package is not treated as "unfree" by
anything else in nixpkgs. Users don‘t get warnings when they use them
and we actually very often build those packages on hydra because they
are dependencies on other packages with free licenses.

This change simply acknowledges the fact that we are already building
and distributing most of these packages by giving them their own hydra
job.

Here are the arguments in favor of this:

* We have been distributing those packages all along and no one complained.
* hackage rules require all packages to be "open source in spirit".
* There are no known unfree packages on hackage.
* If we notice an unfree package we can always declare the package unfree in the
hackage2nix config.

This is the easiest solution to deal with the existing inconsistencies.
All other approaches would be more invasive and would mean more
maintainer overhead.

While this might not be the best overall solution for dealing with
licenses, e.g. we could try to get rid of all stringly licenses, we can
always do that improvements later.