### PR TITLE
hackage2nix: update fixup package blacklist

### DIFF
--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -79,12 +79,10 @@ main = do
   nixpkgs <- readNixpkgPackageMap nixpkgsRepository (Just "{ config = { allowAliases = false; }; }")
   preferredVersions <- readPreferredVersions (fromMaybe (hackageRepository </> "preferred-versions") preferredVersionsFile)
   let fixup = Map.delete "acme-everything"      -- TODO: https://github.com/NixOS/cabal2nix/issues/164
-            . Map.delete "som"                  -- TODO: https://github.com/NixOS/cabal2nix/issues/164
             . Map.delete "type"                 -- TODO: https://github.com/NixOS/cabal2nix/issues/163
             . Map.delete "control-invariants"   -- TODO: depends on "assert"
             . Map.delete "ConcurrentUtils"      -- TODO: depends on "assert"
             . Map.delete "with"                 -- TODO: https://github.com/NixOS/cabal2nix/issues/164
-            . Map.delete "telega"               -- TODO: depends on "with"
             . over (at "hermes") (fmap (set (contains "1.3.4.3") False))  -- TODO: https://github.com/haskell/hackage-server/issues/436
   hackage <- fixup <$> readHackage hackageRepository
   let


### PR DESCRIPTION
som no longer depends on assert and telega no longer on with.