### PR TITLE
shell.nix: Set up ghc environment, add haskell-language-server

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+if type -p lorri; then
+    echo "direnv: found lorri, using" 1>&2
+    eval "$(lorri direnv)"
+else
+    echo "direnv: using direnv nix support" 1>&2
+    use nix;
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,31 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  haskellPackages = pkgs.haskellPackages;
+  ghc = haskellPackages.ghcWithHoogle (hps: [
+    hps.ansi-wl-pprint
+    hps.distribution-nixpkgs
+    hps.hackage-db
+    hps.hopenssl
+    hps.hpack
+    hps.language-nix
+    hps.lens
+    hps.optparse-applicative
+    hps.pretty
+    hps.split
+    hps.yaml
+    hps.monad-par
+    hps.monad-par-extras
+    hps.tasty
+    hps.tasty-golden
+  ]);
+
+in pkgs.stdenv.mkDerivation {
+  name = "shell";
+  buildInputs = [
+            ghc
+            haskellPackages.cabal-install
+            haskellPackages.haskell-language-server
+            (pkgs.lib.getLib pkgs.openssl)
+          ];
+}


### PR DESCRIPTION
Manually lists the nix dependencies required by cabal2nix; this of
course requires that the local <nixpkgs> version agrees with the
package versions of cabal2nix dependencies, so ymmv.