### PR TITLE
Refactors (ApplicativeDo, record syntax, fetchWith)

### DIFF
--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -224,7 +224,12 @@ hpackOverrides = over phaseOverrides (++ "prePatch = \"hpack\";")
 cabal2nix' :: Options -> IO (Either Doc Derivation)
 cabal2nix' opts@Options{..} = do
   pkg <- getPackage optHpack optFetchSubmodules optHackageDb optHackageSnapshot $
-         Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
+         Source {
+           sourceUrl = optUrl,
+           sourceRevision = fromMaybe "" optRevision,
+           sourceHash = maybe UnknownHash Guess optSha256,
+           sourceCabalDir = fromMaybe "" optSubpath
+         }
   processPackage opts pkg
 
 cabal2nixWithDB :: DB.HackageDB -> Options -> IO (Either Doc Derivation)
@@ -232,7 +237,12 @@ cabal2nixWithDB db opts@Options{..} = do
   when (isJust optHackageDb) $ hPutStrLn stderr "WARN: HackageDB provided directly; ignoring --hackage-db"
   when (isJust optHackageSnapshot) $ hPutStrLn stderr "WARN: HackageDB provided directly; ignoring --hackage-snapshot"
   pkg <- getPackage' optHpack optFetchSubmodules (return db) $
-         Source optUrl (fromMaybe "" optRevision) (maybe UnknownHash Guess optSha256) (fromMaybe "" optSubpath)
+         Source {
+           sourceUrl = optUrl,
+           sourceRevision = fromMaybe "" optRevision,
+           sourceHash = maybe UnknownHash Guess optSha256,
+           sourceCabalDir = fromMaybe "" optSubpath
+         }
   processPackage opts pkg
 
 processPackage :: Options -> Package -> IO (Either Doc Derivation)

--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -227,7 +227,9 @@ cabal2nix' opts@Options{..} = do
          Source {
            sourceUrl = optUrl,
            sourceRevision = fromMaybe "" optRevision,
-           sourceHash = maybe UnknownHash Guess optSha256,
+           sourceHash = case optSha256 of
+             Nothing -> UnknownHash
+             Just hash -> Guess hash,
            sourceCabalDir = fromMaybe "" optSubpath
          }
   processPackage opts pkg
@@ -240,7 +242,9 @@ cabal2nixWithDB db opts@Options{..} = do
          Source {
            sourceUrl = optUrl,
            sourceRevision = fromMaybe "" optRevision,
-           sourceHash = maybe UnknownHash Guess optSha256,
+           sourceHash = case optSha256 of
+             Nothing -> UnknownHash
+             Just hash -> Guess hash,
            sourceCabalDir = fromMaybe "" optSubpath
          }
   processPackage opts pkg

--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -67,7 +67,7 @@ data Options = Options
   , optHackageSnapshot :: Maybe UTCTime
   , optNixpkgsIdentifier :: NixpkgsResolver
   , optUrl :: String
-  , optFetchSubmodules :: Bool
+  , optFetchSubmodules :: FetchSubmodules
   }
 
 options :: Parser Options
@@ -125,7 +125,7 @@ options = do
   optUrl
     <- strArgument (metavar "URI")
   optFetchSubmodules
-    <- flag True False (long "dont-fetch-submodules" <> help "do not fetch git submodules from git sources")
+    <- flag FetchSubmodules DontFetchSubmodules  (long "dont-fetch-submodules" <> help "do not fetch git submodules from git sources")
   pure Options{..}
 
 -- | A parser for the date. Hackage updates happen maybe once or twice a month.

--- a/src/Distribution/Nixpkgs/Haskell/Derivation.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Derivation.hs
@@ -66,7 +66,7 @@ data Derivation = MkDerivation
   , _enableSeparateDataOutput   :: Bool
   , _metaSection                :: Meta
   }
-  deriving (Show, Eq, Generic)
+  deriving (Show, Generic)
 
 nullDerivation :: Derivation
 nullDerivation = MkDerivation
@@ -147,7 +147,9 @@ instance Pretty Derivation where
       inputs :: Set String
       inputs = Set.unions [ Set.map (view (localName . ident)) _extraFunctionArgs
                           , setOf (dependencies . each . folded . localName . ident) drv
-                          , Set.fromList ["fetch" ++ derivKind _src | derivKind _src /= "" && not isHackagePackage]
+                          , case derivKind _src of
+                              Nothing -> mempty
+                              Just derivKind' -> Set.fromList [derivKindFunction derivKind' | not isHackagePackage]
                           ]
 
       renderedFlags = [ text "-f" <> (if enable then empty else char '-') <> text (unFlagName f) | (f, enable) <- unFlagAssignment _cabalFlags ]

--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -180,7 +180,7 @@ sourceFromHackage optHash pkgId cabalDir = do
       maybeHash <- runMaybeT
         $ derivHash . fst
         <$> fetchWith
-              (False, "url", Nothing, [])
+              (False, DerivKindUrl, Nothing, [])
               (Source {
                 sourceUrl = url,
                 sourceRevision = "",

--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -49,7 +49,7 @@ data Package = Package
 
 getPackage :: HpackUse
            -- ^ the way hpack should be used.
-           -> Bool
+           -> FetchSubmodules
            -- ^ Whether to fetch submodules if fetching from git
            -> Maybe FilePath
            -- ^ The path to the Hackage database.
@@ -62,7 +62,7 @@ getPackage optHpack optSubmodules optHackageDB optHackageSnapshot =
 
 getPackage' :: HpackUse
             -- ^ the way hpack should be used.
-            -> Bool
+            -> FetchSubmodules
             -- ^ Whether to fetch submodules if fetching from git
             -> IO DB.HackageDB
             -> Source
@@ -85,7 +85,7 @@ getPackage' optHpack optSubmodules hackageDB source = do
 
 fetchOrFromDB :: HpackUse
               -- ^ the way hpack should be used
-              -> Bool
+              -> FetchSubmodules
               -- ^ Whether to fetch submodules if fetching from git
               -> IO DB.HackageDB
               -> Source
@@ -180,7 +180,7 @@ sourceFromHackage optHash pkgId cabalDir = do
       maybeHash <- runMaybeT
         $ derivHash . fst
         <$> fetchWith
-              (False, DerivKindUrl, [])
+              (False, DerivKindUrl DontUnpackArchive)
               (Source {
                 sourceUrl = url,
                 sourceRevision = "",

--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -180,7 +180,7 @@ sourceFromHackage optHash pkgId cabalDir = do
       maybeHash <- runMaybeT
         $ derivHash . fst
         <$> fetchWith
-              (False, DerivKindUrl, Nothing, [])
+              (False, DerivKindUrl, [])
               (Source {
                 sourceUrl = url,
                 sourceRevision = "",

--- a/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -160,7 +160,16 @@ sourceFromHackage optHash pkgId cabalDir = do
       seq (length hash) $
       urlDerivationSource url hash <$ writeFile cacheFile hash
     UnknownHash -> do
-      maybeHash <- runMaybeT (derivHash . fst <$> fetchWith (False, "url", Nothing, []) (Source url "" UnknownHash cabalDir))
+      maybeHash <- runMaybeT
+        $ derivHash . fst
+        <$> fetchWith
+              (False, "url", Nothing, [])
+              (Source {
+                sourceUrl = url,
+                sourceRevision = "",
+                sourceHash = UnknownHash,
+                sourceCabalDir = cabalDir
+              })
       case maybeHash of
         Just hash ->
           seq (length hash) $

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -56,7 +56,7 @@ testLibrary cabalFile = do
                          []
                          gpd
                        & src .~ DerivationSource
-                                  { derivKind     = "url"
+                                  { derivKind     = Just DerivKindUrl
                                   , derivUrl      = "mirror://hackage/foo.tar.gz"
                                   , derivRevision = ""
                                   , derivHash     = "deadbeef"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -56,7 +56,7 @@ testLibrary cabalFile = do
                          []
                          gpd
                        & src .~ DerivationSource
-                                  { derivKind     = Just DerivKindUrl
+                                  { derivKind     = Just (DerivKindUrl DontUnpackArchive )
                                   , derivUrl      = "mirror://hackage/foo.tar.gz"
                                   , derivRevision = ""
                                   , derivHash     = "deadbeef"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Main ( main ) where
 
@@ -31,7 +32,9 @@ main = do
   --       depend on the system environment: https://github.com/NixOS/cabal2nix/issues/333.
   --
   -- TODO: Run this test without $HOME defined to ensure that we don't need that variable.
-  cabal2nix <- findExecutable "cabal2nix" >>= maybe (fail "cannot find 'cabal2nix' in $PATH") return
+  cabal2nix <- findExecutable "cabal2nix" >>= \case
+    Nothing -> fail "cannot find 'cabal2nix' in $PATH"
+    Just exe -> pure exe
   testCases <- listDirectoryFilesBySuffix ".cabal" "test/golden-test-cases"
   defaultMain $ testGroup "regression-tests"
     [ testGroup "cabal2nix library" (map testLibrary testCases)


### PR DESCRIPTION
These are a few code refactors, 

* use `ApplicativeDo` where possible
* use explicity record syntax instead of ordering-dependent constructors
* reduce complexity of `fetchWith` by moving most arguments into a single enum in multiple steps