### PR TITLE
doc: update `README.md` code block syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,19 @@ Cabal2nix
 `cabal2nix` converts a single Cabal file into a single Nix build expression.
 For example:
 
-    $ cabal2nix cabal://mtl
-    { mkDerivation, base, lib, transformers }:
-    mkDerivation {
-      pname = "mtl";
-      version = "2.2.1";
-      sha256 = "1icdbj2rshzn0m1zz5wa7v3xvkf6qw811p4s7jgqwvx1ydwrvrfa";
-      libraryHaskellDepends = [ base transformers ];
-      homepage = "http://github.com/ekmett/mtl";
-      description = "Monad classes, using functional dependencies";
-      license = lib.licenses.bsd3;
-    }
+```console
+$ cabal2nix cabal://mtl
+{ mkDerivation, base, lib, transformers }:
+mkDerivation {
+  pname = "mtl";
+  version = "2.2.1";
+  sha256 = "1icdbj2rshzn0m1zz5wa7v3xvkf6qw811p4s7jgqwvx1ydwrvrfa";
+  libraryHaskellDepends = [ base transformers ];
+  homepage = "http://github.com/ekmett/mtl";
+  description = "Monad classes, using functional dependencies";
+  license = lib.licenses.bsd3;
+}
+```
 
 Cabal files can be referred to using the magic URL `cabal://NAME-VERSION`,
 which will automatically download the file from Hackage. Alternatively, a
@@ -38,18 +40,20 @@ Hackage. You only need to provide a URI that points to a cabal project. The
 most common use-case for this is probably to generate a derivation for a
 project on the local file system:
 
-    $ cabal get mtl-2.2.1 && cd mtl-2.2.1
-    $ cabal2nix .
-    { mkDerivation, base, lib, transformers }:
-    mkDerivation {
-      pname = "mtl";
-      version = "2.2.1";
-      src = ./.;
-      libraryHaskellDepends = [ base transformers ];
-      homepage = "http://github.com/ekmett/mtl";
-      description = "Monad classes, using functional dependencies";
-      license = lib.licenses.bsd3;
-    }
+```console
+$ cabal get mtl-2.2.1 && cd mtl-2.2.1
+$ cabal2nix .
+{ mkDerivation, base, lib, transformers }:
+mkDerivation {
+  pname = "mtl";
+  version = "2.2.1";
+  src = ./.;
+  libraryHaskellDepends = [ base transformers ];
+  homepage = "http://github.com/ekmett/mtl";
+  description = "Monad classes, using functional dependencies";
+  license = lib.licenses.bsd3;
+}
+```
 
 This derivation will not fetch from hackage, but instead use the directory which
 contains the derivation as the source repository.


### PR DESCRIPTION
other code blocks use the `console` formatted blocks, this change makes that formatting consistent across other code blocks.

[rendered version](https://github.com/NixOS/cabal2nix/blob/8471aa5ab846a4ee8109c8bc284bedc0570444ed/README.md) compared to [current](https://github.com/NixOS/cabal2nix/blob/master/README.md)