### PR TITLE
Distribution.Nixpkgs.Haskell.Platform: unify CLI platform parsing

### DIFF
--- a/cabal2nix.cabal
+++ b/cabal2nix.cabal
@@ -44,6 +44,7 @@ library
                       Distribution.Nixpkgs.Haskell.Hackage
                       Distribution.Nixpkgs.Haskell.OrphanInstances
                       Distribution.Nixpkgs.Haskell.PackageSourceSpec
+                      Distribution.Nixpkgs.Haskell.Platform
   other-modules:      Paths_cabal2nix
   hs-source-dirs:     src
   build-depends:      base                 > 4.11

--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -16,13 +16,13 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.Set ( Set )
 import qualified Data.Set as Set
-import Data.String
 import Distribution.Nixpkgs.Fetch
 import Distribution.Nixpkgs.Haskell as Derivation
 import Distribution.Nixpkgs.Haskell.Constraint
 import Distribution.Nixpkgs.Haskell.FromCabal
 import Distribution.Nixpkgs.Haskell.FromCabal.Configuration as Config
 import Distribution.Nixpkgs.Haskell.FromCabal.Flags
+import Distribution.Nixpkgs.Haskell.Platform ( parsePlatformFromSystemLenient )
 import Distribution.Nixpkgs.Haskell.OrphanInstances ( )
 import Distribution.Nixpkgs.Meta
 import Distribution.Nixpkgs.PackageMap
@@ -62,7 +62,7 @@ main = do
         <*> optional (strOption (long "preferred-versions" <> help "path to Hackage preferred-versions file" <> value "hackage/preferred-versions" <> showDefault <> metavar "PATH"))
         <*> strOption (long "nixpkgs" <> help "path to Nixpkgs repository" <> value "nixpkgs" <> showDefaultWith id <> metavar "PATH")
         <*> some1 (strOption (long "config" <> help "path to configuration file inside of Nixpkgs" <> metavar "PATH"))
-        <*> option (fmap fromString str) (long "platform" <> help "target platform to generate package set for" <> value "x86_64-linux" <> showDefaultWith display <> metavar "PLATFORM")
+        <*> option (maybeReader parsePlatformFromSystemLenient) (long "platform" <> help "target platform to generate package set for" <> value (Platform X86_64 Linux) <> showDefaultWith display <> metavar "PLATFORM")
 
       pinfo :: ParserInfo CLI
       pinfo = info

--- a/src/Cabal2nix.hs
+++ b/src/Cabal2nix.hs
@@ -12,9 +12,7 @@ module Cabal2nix
 import Control.Exception ( bracket )
 import Control.Lens
 import Control.Monad
-import Data.List ( intercalate, isPrefixOf )
-import Data.List.Split
-import Data.Maybe ( fromMaybe, isJust, listToMaybe )
+import Data.Maybe ( fromMaybe, isJust )
 import qualified Data.Set as Set
 import Data.String
 import Data.Time
@@ -23,6 +21,7 @@ import Distribution.Nixpkgs.Fetch
 import Distribution.Nixpkgs.Haskell
 import Distribution.Nixpkgs.Haskell.FromCabal
 import Distribution.Nixpkgs.Haskell.FromCabal.Flags
+import Distribution.Nixpkgs.Haskell.Platform
 import qualified Distribution.Nixpkgs.Haskell.FromCabal.PostProcess as PP (pkg)
 import qualified Distribution.Nixpkgs.Haskell.Hackage as DB
 import Distribution.Nixpkgs.Haskell.OrphanInstances ( )
@@ -115,7 +114,7 @@ options = do
   optCompiler
     <- option parseCabal (long "compiler" <> help "compiler to use when evaluating the Cabal file" <> value buildCompilerId <> showDefaultWith prettyShow)
   optSystem
-    <- option (maybeReader parsePlatform) (long "system" <> help "host system (in either short Nix format or full LLVM style) to use when evaluating the Cabal file" <> value buildPlatform <> showDefaultWith prettyShow)
+    <- option (maybeReader parsePlatformLenient) (long "system" <> help "host system (in either short Nix format or full LLVM style) to use when evaluating the Cabal file" <> value buildPlatform <> showDefaultWith prettyShow)
   optSubpath
     <- optional (strOption $ long "subpath" <> metavar "PATH" <> help "Path to Cabal file's directory relative to the URI (default is root directory)")
   optHackageSnapshot
@@ -138,53 +137,6 @@ utcTimeReader = eitherReader $ \arg ->
 
 parseCabal :: Parsec a => ReadM a
 parseCabal = eitherReader eitherParsec
-
--- | Replicate the normalization performed by GHC_CONVERT_CPU in GHC's aclocal.m4
--- since the output of that is what Cabal parses.
-ghcConvertArch :: String -> String
-ghcConvertArch arch = case arch of
-  "i486"  -> "i386"
-  "i586"  -> "i386"
-  "i686"  -> "i386"
-  "amd64" -> "x86_64"
-  _ -> fromMaybe arch $ listToMaybe
-    [prefix | prefix <- archPrefixes, prefix `isPrefixOf` arch]
-  where archPrefixes =
-          [ "aarch64", "alpha", "arm", "hppa1_1", "hppa", "m68k", "mipseb"
-          , "mipsel", "mips", "powerpc64le", "powerpc64", "powerpc", "s390x"
-          , "sparc64", "sparc"
-          ]
-
--- | Replicate the normalization performed by GHC_CONVERT_OS in GHC's aclocal.m4
--- since the output of that is what Cabal parses.
-ghcConvertOS :: String -> String
-ghcConvertOS os = case os of
-  "watchos"       -> "ios"
-  "tvos"          -> "ios"
-  "linux-android" -> "linux-android"
-  "linux-androideabi" -> "linux-androideabi"
-  _ | "linux-" `isPrefixOf` os -> "linux"
-  _ -> fromMaybe os $ listToMaybe
-    [prefix | prefix <- osPrefixes, prefix `isPrefixOf` os]
-  where osPrefixes =
-          [ "gnu", "openbsd", "aix", "darwin", "solaris2", "freebsd", "nto-qnx"]
-
-parseArch :: String -> Arch
-parseArch = classifyArch Permissive . ghcConvertArch
-
-parseOS :: String -> OS
-parseOS = classifyOS Permissive . ghcConvertOS
-
-parsePlatform :: String -> Maybe Platform
-parsePlatform = parsePlatformParts . splitOn "-"
-
-parsePlatformParts :: [String] -> Maybe Platform
-parsePlatformParts = \case
-  [arch, os] ->
-    Just $ Platform (parseArch arch) (parseOS os)
-  (arch : _ : osParts) ->
-    Just $ Platform (parseArch arch) $ parseOS $ intercalate "-" osParts
-  _ -> Nothing
 
 pinfo :: ParserInfo Options
 pinfo = info

--- a/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
+++ b/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Distribution.Nixpkgs.Haskell.OrphanInstances ( ) where
 
@@ -35,18 +36,16 @@ instance IsString PackageVersionConstraint where
 instance IsString CompilerId where
   fromString = text2isString "CompilerId"
 
-instance IsString Platform where
-  fromString "i686-linux" = Platform I386 Linux
-  fromString "x86_64-linux" = Platform X86_64 Linux
-  fromString "x86_64-darwin" = Platform X86_64 OSX
-  fromString "aarch64-linux" = Platform AArch64 Linux
-  fromString "aarch64-darwin" = Platform AArch64 OSX
-  fromString "armv7l-linux" = Platform (OtherArch "armv7l") Linux
-  fromString s = error ("fromString: " ++ show s ++ " is not a valid platform")
-
 instance FromJSON Platform where
-  parseJSON (String s) = pure (fromString (T.unpack s))
-  parseJSON s = fail ("parseJSON: " ++ show s ++ " is not a valid platform")
+  parseJSON s =
+    case s of
+      (String "i686-linux") -> pure $ Platform I386 Linux
+      (String "x86_64-linux") -> pure $ Platform X86_64 Linux
+      (String "x86_64-darwin") -> pure $ Platform X86_64 OSX
+      (String "aarch64-linux") -> pure $ Platform AArch64 Linux
+      (String "aarch64-darwin") -> pure $ Platform AArch64 OSX
+      (String "armv7l-linux") -> pure $ Platform (OtherArch "armv7l") Linux
+      _ -> fail ("parseJSON: " ++ show s ++ " is not a valid platform")
 
 instance FromJSON PackageName where
   parseJSON (String s) = return (fromString (T.unpack s))

--- a/src/Distribution/Nixpkgs/Haskell/Platform.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Platform.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE LambdaCase #-}
+{-|
+Description: Parse platform strings used by nixpkgs into Cabal's 'Platform'
+
+This module defines conversions from the (autoconf-derived) platform strings
+nixpkgs uses into Cabal's 'Platform' type. This is intended to facilitate later
+evaluation of @.cabal@ files. For this conversion Cabal's 'Permissive'
+heuristics are used as well as a logic equivalent to the @GHC_CONVERT_*@ macros
+from GHC's configure script.
+
+Since the process is inherently lossy because Cabal ignores certain factors like
+endianness, conversion from 'Platform' to nixpkgs' platform strings. For this
+usecase, try "Distribution.Nixpkgs.Meta" from @distribution-nixpkgs@.
+-}
+module Distribution.Nixpkgs.Haskell.Platform
+  ( parsePlatformLenient
+  , parsePlatformFromSystemLenient
+  ) where
+
+import Data.List ( isPrefixOf, intercalate )
+import Data.List.Split ( splitOn )
+import Data.Maybe ( fromMaybe, listToMaybe )
+import Distribution.System
+
+-- | Replicate the normalization performed by GHC_CONVERT_CPU in GHC's aclocal.m4
+-- since the output of that is what Cabal parses.
+ghcConvertArch :: String -> String
+ghcConvertArch arch = case arch of
+  "i486"  -> "i386"
+  "i586"  -> "i386"
+  "i686"  -> "i386"
+  "amd64" -> "x86_64"
+  _ -> fromMaybe arch $ listToMaybe
+    [prefix | prefix <- archPrefixes, prefix `isPrefixOf` arch]
+  where archPrefixes =
+          [ "aarch64", "alpha", "arm", "hppa1_1", "hppa", "m68k", "mipseb"
+          , "mipsel", "mips", "powerpc64le", "powerpc64", "powerpc", "s390x"
+          , "sparc64", "sparc"
+          ]
+
+-- | Replicate the normalization performed by GHC_CONVERT_OS in GHC's aclocal.m4
+-- since the output of that is what Cabal parses.
+ghcConvertOS :: String -> String
+ghcConvertOS os = case os of
+  "watchos"       -> "ios"
+  "tvos"          -> "ios"
+  "linux-android" -> "linux-android"
+  "linux-androideabi" -> "linux-androideabi"
+  _ | "linux-" `isPrefixOf` os -> "linux"
+  _ -> fromMaybe os $ listToMaybe
+    [prefix | prefix <- osPrefixes, prefix `isPrefixOf` os]
+  where osPrefixes =
+          [ "gnu", "openbsd", "aix", "darwin", "solaris2", "freebsd", "nto-qnx"]
+
+parseArch :: String -> Arch
+parseArch = classifyArch Permissive . ghcConvertArch
+
+parseOS :: String -> OS
+parseOS = classifyOS Permissive . ghcConvertOS
+
+parsePlatformParts :: [String] -> Maybe Platform
+parsePlatformParts = \case
+  [arch, os] ->
+    Just $ Platform (parseArch arch) (parseOS os)
+  (arch : _ : osParts) ->
+    Just $ Platform (parseArch arch) $ parseOS $ intercalate "-" osParts
+  _ -> Nothing
+
+-- | Convert a platform string of two or three(-ish) components to 'Platform'.
+--
+--   For this, the following logic is utilized:
+--
+--   - If the string has one dash, the form @cpu-os@ is assumed where @os@ may
+--     only have a single component. The @vendor@ part is ignored.
+--
+--   - Otherwise @cpu-vendor-os@ is assumed where @os@ may have any number of
+--     components separated by dashes to accomodate its two component
+--     @kernel-system@ form.
+--
+--   __Note:__ This behavior is different from nixpkgs' @lib.systems.elaborate@:
+--   Because we have no knowledge of the legal contents of the different parts,
+--   we only decide how to parse it based on what form the string has. This can
+--   give different results compared to autoconf or nixpkgs. It will also never
+--   reject an invalid platform string that has a valid form.
+--
+--   >>> parsePlatformLenient "x86_64-unknown-linux"
+--   Just (Platform X86_64 Linux)
+--   >>> parsePlatformLenient "x86_64-pc-linux-gnu"
+--   Just (Platform X86_64 Linux)
+--   >>> parsePlatformLenient "x86_64-linux"
+--   Just (Platform X86_64 Linux)
+--
+--   __Note__ also that this conversion sometimes looses information nixpkgs
+--   would retain:
+--
+--   >>> parsePlatformLenient "powerpc64-unknown-linux"
+--   Just (Platform PPC64 Linux)
+--   >>> parsePlatformLenient "powerpc64le-unknown-linux"
+--   Just (Platform PPC64 Linux)
+parsePlatformLenient :: String -> Maybe Platform
+parsePlatformLenient = parsePlatformParts . splitOn "-"
+
+-- | Convert a Nix style system tuple into a Cabal 'Platform'. The tuple is
+--   assumed to be of the form @cpu-os@, any extra components are assumed to be
+--   part of @os@ to accomodate its @kernel-system@ form.
+--
+--   The same caveats about validation and lossiness apply as for
+--   'parsePlatformLenient'.
+--
+--   >>> parsePlatformFromSystemLenient "x86_64-linux"
+--   Just (Platform X86_64 Linux)
+--   >>> parsePlatformFromSystemLenient "x86_64-linux-musl"
+--   Just (Platform X86_64 Linux)
+--   >>> parsePlatformFromSystemLenient "i686-netbsd"
+--   Just (Platform I386 NetBSD)
+parsePlatformFromSystemLenient :: String -> Maybe Platform
+parsePlatformFromSystemLenient s =
+  case break (== '-') s of
+    (arch, '-':os) ->
+      if null arch || null os
+      then Nothing
+      else parsePlatformParts [arch, os]
+    _ -> Nothing


### PR DESCRIPTION
In the cabal2nix project there are two flags that accept some kind of
string that needs to be converted to a `Platform` which is used for
evaluating a `.cabal` file:

* cabal2nix: `--system` accepts `cpu-vendor-os` and `cpu-os`
* hackage2nix: `--platform` only accepts `cpu-os`.

Their names should be swapped, ironically compared to what they do which
should be tackled eventually.

Initially I thought the parsing of these could be replaced by
distribution-nixpkgs new capabilities, but ran into the following issue:
distribution-nixpkgs needs to be lossless, since `Platform`s need to be
rendered again.

This is problematic when evaluating Cabal files, however: Cabal has no
notion of powerpc64le and powerpc64 and GHC's conversion logic causes
them to be both interpreted as PPC64. Package authors likely expect this
behavior, so we risk accidentally getting wrong results by insisting on
losslessness.

To tackle this, we'll have two different ways to parse a
nixpkgs-originating string into a `Platform`:

* One in distribution-nixpkgs to parse into a `NixpkgsPlatformSingle`
* One in cabal2nix to parse into a genuine Cabal `Platform`