### PR TITLE
hackage2nix: don't discard platforms meta attr from postprocessing

### DIFF
--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -157,8 +157,10 @@ main = do
           drv = fromGenericPackageDescription haskellResolver nixpkgsResolver targetPlatform (compilerInfo config) flagAssignment [] descr
                   & src .~ urlDerivationSource ("mirror://hackage/" ++ display pkgId ++ ".tar.gz") tarballSHA256
                   & editedCabalFile .~ cabalSHA256
-                  & metaSection.platforms .~ Map.lookup name (supportedPlatforms config)
-                  & metaSection.badPlatforms .~ Map.lookup name (unsupportedPlatforms config)
+                  -- If a list of platforms is set in the hackage2nix configuration file, prefer that.
+                  -- Otherwise a list defined by PostProcess or Nothing is used.
+                  & metaSection.platforms %~ (Map.lookup name (supportedPlatforms config) <|>)
+                  & metaSection.badPlatforms %~ (Map.lookup name (unsupportedPlatforms config) <|>)
                   & metaSection.hydraPlatforms %~ (if isHydraEnabled then id else const (Just Set.empty))
                   & metaSection.broken ||~ isBroken
                   & metaSection.maintainers .~ Map.findWithDefault Set.empty name globalPackageMaintainers


### PR DESCRIPTION
Distribution.Nixpkgs.Haskell.FromCabal.PostProcess defines logic that in
some cases prescribes a list of platforms. Currently this gets discarded
in hackage2nix which is a bug introduced in #506.

Before said PR, hackage2nix used a fairly elaborate logic involving Set
subtraction which was necessary because the default value would be
allKnownPlatforms. Instead of that we can now use a very simple logic:
We use whatever is set or not set by PostProcess / cabal2nix in general
and then allow whatever is yielded by that to be overwritten by the
configuration passed to hackage2nix.