### PR TITLE
Add FLAC -> flac system library mapping

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs
@@ -45,6 +45,7 @@ libNixName "dl"                                 = []  -- provided by glibc
 libNixName "ff"                                 = return "libff"
 libNixName "fftw3"                              = return "fftw"
 libNixName "fftw3f"                             = return "fftwFloat"
+libNixName "FLAC"                               = return "flac"
 libNixName "freetype2"                          = return "freetype"
 libNixName "gconf"                              = return "GConf"
 libNixName "gconf-2.0"                          = return "GConf"


### PR DESCRIPTION
This should fix the build of (at least) the [`flac`](https://hackage.haskell.org/package/flac) hackage package.

closes https://github.com/NixOS/cabal2nix/issues/566