### PR TITLE
hackage-db: Fix the type of signatures in metadata

### DIFF
--- a/hackage-db/src/Distribution/Hackage/DB/MetaData.hs
+++ b/hackage-db/src/Distribution/Hackage/DB/MetaData.hs
@@ -35,7 +35,7 @@ parseMetaData :: ByteString -> MetaData
 parseMetaData = either (throw . InvalidMetaFile) id . eitherDecode
 
 data MetaData = MetaData { signed :: SignedMetaData
-                         , signatures :: [String]
+                         , signatures :: [Signature]
                          }
   deriving (Show, Generic)
 
@@ -56,3 +56,10 @@ data TargetData = TargetData { length :: Int
   deriving (Show, Generic)
 
 instance FromJSON TargetData
+
+data Signature = Signature { keyid :: String
+                           , method :: String
+                           , sig :: String }
+  deriving (Show, Generic)
+
+instance FromJSON Signature


### PR DESCRIPTION
Previous PR/discussion: https://github.com/NixOS/hackage-db/pull/17

---

Signatures are actually complex objects. We could use `Value` here since it's unlikely that any consumers care about this, but it's cheap enough to just define a structure for the signature objects.

In practice this isn't an issue because it seems like this field is never populated in Hackage, but it can be populated if you build a custom Hackage it can happen.

Fixes #573.

cc @michaelpj (sorry for the repository moving mess)

