### PR TITLE
distribution-nixpkgs: prepare 1.7.0.1 release

### DIFF
--- a/distribution-nixpkgs/CHANGELOG.md
+++ b/distribution-nixpkgs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for distribution-nixpkgs
 
+## 1.7.0.1
+
+* Adapt test suite to changed representation of some `Platform`s in Cabal 3.8.
+* Update test data to include new nixpkgs architectures `rx`, `microblaze` and
+  `microblazeel`.
+* The distribution-nixpkgs repository has been merged into the
+  [cabal2nix](https://github.com/NixOS/cabal2nix) repository.
+  All URLs in the cabal file have been updated and the distribution-nixpkgs
+  repository will be archived.
+
 ## 1.7.0
 
 * `Distribution.Nixpkgs.Meta`

--- a/distribution-nixpkgs/distribution-nixpkgs.cabal
+++ b/distribution-nixpkgs/distribution-nixpkgs.cabal
@@ -1,5 +1,5 @@
 name:          distribution-nixpkgs
-version:       1.7.0
+version:       1.7.0.1
 synopsis:      Types and functions to manipulate the Nixpkgs distribution
 description:   Types and functions to represent, query, and manipulate the Nixpkgs distribution.
 license:       BSD3


### PR DESCRIPTION
This release is mostly for the benefit of `haskell.packages.ghc942`, since we currently need to disable the test suite there.