### PR TITLE
Flake-enable project

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,4 +7,4 @@
     }
   )
   { src = ./.; }
-).shellNix
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "v1.0.0",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669926280,
+        "narHash": "sha256-FP+ko5UBkGDWzmS12aP2yq7ZMVYC25JkpBpWzWSKjqI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b7143a45499e7c2689ef13e0962751ab39347ed9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,87 @@
+{ inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    flake-utils.url = "github:numtide/flake-utils/v1.0.0";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        ghcVersion = "ghc90";
+
+        config = { };
+
+        overlay = self: super: {
+          haskell = super.haskell // {
+            packages = super.haskell.packages // {
+              "${ghcVersion}" = super.haskell.packages."${ghcVersion}".override (old: {
+                overrides =
+                  self.lib.composeExtensions
+                    (old.overrides or (_: _: { }))
+                    (hself: hsuper: {
+                      # The reason we stick these underneath a `local` attribute
+                      # is to avoid infinite recursion (because `callCabal2nix`
+                      # depends on all of these packages.
+                      local = rec {
+                        cabal2nix =
+                          hself.callCabal2nix "cabal2nix" ./cabal2nix {
+                            inherit distribution-nixpkgs hackage-db;
+                          };
+
+                        distribution-nixpkgs =
+                          hself.callCabal2nix
+                            "distribution-nixpkgs"
+                            ./distribution-nixpkgs
+                            { inherit language-nix; };
+
+                        hackage-db =
+                          hself.callCabal2nix "hackage-db" ./hackage-db { };
+
+                        language-nix =
+                          hself.callCabal2nix "language-nix" ./language-nix { };
+                      };
+                    });
+              });
+            };
+          };
+        };
+
+        pkgs =
+          import nixpkgs { inherit config system; overlays = [ overlay ]; };
+
+      in
+        rec {
+          packages = rec {
+            inherit (pkgs.haskell.packages."${ghcVersion}".local)
+              cabal2nix
+              hackage-db
+              distribution-nixpkgs
+              language-nix
+            ;
+
+            default = cabal2nix;
+          };
+
+          devShells = rec {
+            cabal2nix =
+              pkgs.haskell.packages."${ghcVersion}".local.cabal2nix.env;
+
+            distribution-nixpkgs =
+              pkgs.haskell.packages."${ghcVersion}".local.distribution-nixpkgs.env;
+
+            hackage-db =
+              pkgs.haskell.packages."${ghcVersion}".local.hackage-db.env;
+
+            language-nix =
+              pkgs.haskell.packages."${ghcVersion}".local.language-nix.env;
+
+            default = cabal2nix;
+          };
+        }
+    );
+}


### PR DESCRIPTION
The immediate motivation for doing this was that
the old `shell.nix` failed with the `nixpkgs` channel that I had installed.  While I was fixing this to pin `nixpkgs` I figured this would be a good time to flake-enable the project.