### PR TITLE
hackage-db: support cabal-install 3.10.1.0 XDG paths.

### DIFF
--- a/hackage-db/CHANGELOG.md
+++ b/hackage-db/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Revision history for hackage-db
 
+## 2.1.3
+
+* `hackageTarball` / `cabalStateDir` now support overriding the cabal directory
+  location by setting the `CABAL_DIR` environment variable. This is useful if
+  `hackage-db` doesn't detect the correct location on its own:
+
+  - A matching cabal state directory may exist, but should not be used for some
+    reason.
+
+  - A non-standard cabal state directory may be used, but `hackage-db` can't
+    find it (as it doesn't check the `cabal-install` configuration file).
+
+* `hackageTarball` now supports all state dir location(s) (newly) supported by
+  `cabal-install`. If `CABAL_DIR` is not set, it will look in the following
+  locations in that order:
+
+  1. `$HOME/.cabal`, the classic location, will be preferred if it exists.
+  2. `$XDG_CACHE_HOME/cabal` (usually `$HOME/.cache/cabal`) is used otherwise.
+     `cabal-install` 3.10.1.0 and newer will default to this location for
+     fresh installations.
+
 ## 2.1.2
 
 Fix a bug which lead to `parsePackageData` always failing if the package had

--- a/hackage-db/hackage-db.cabal
+++ b/hackage-db/hackage-db.cabal
@@ -1,5 +1,5 @@
 name:          hackage-db
-version:       2.1.2
+version:       2.1.3
 synopsis:      Access cabal-install's Hackage database via Data.Map
 description:   This library provides convenient access to the local copy of the Hackage
                database that \"cabal update\" creates. Check out

--- a/hackage-db/src/Distribution/Hackage/DB/Path.hs
+++ b/hackage-db/src/Distribution/Hackage/DB/Path.hs
@@ -15,31 +15,37 @@ import Distribution.Hackage.DB.Errors
 
 import Control.Exception
 import System.Directory
+import System.Environment (lookupEnv)
 import System.FilePath
 
 -- |
 -- Determines the /state/ directory (which e.g. holds the hackage tarball)
 -- cabal-install uses via the following logic:
 --
--- 1. If @~/.cabal@ (see 'getAppUserDataDirectory') exists, use that.
--- 2. Otherwise, use @${XDG_CACHE_HOME}/cabal@ (see @'getXdgDirectory' 'XdgCache'@)
+-- 1. If the @CABAL_DIR@ environment variable is set, its content is used as the
+--    cabal state directory
+-- 2. If @~/.cabal@ (see 'getAppUserDataDirectory') exists, use that.
+-- 3. Otherwise, use @${XDG_CACHE_HOME}/cabal@ (see @'getXdgDirectory' 'XdgCache'@)
 --    which is the new directory cabal-install can use starting with
 --    version @3.10.*@.
 --
 -- This logic is mostly equivalent to what upstream cabal-install is
 -- [doing](https://github.com/haskell/cabal/blob/0ed12188525335ac9759dc957d49979ab09382a1/cabal-install/src/Distribution/Client/Config.hs#L594-L610)
--- with the following exceptions:
---
--- * The @CABAL_DIR@ environment variable is not supported at the moment.
--- * The state directory can freely be configured to use a different location
---   in the cabal-install configuration file. hackage-db doesn't parse this
---   configuration file, so differing state directories are ignored.
+-- with the following exception:
+-- The state directory can freely be configured to use a different location
+-- in the cabal-install configuration file. hackage-db doesn't parse this
+-- configuration file, so differing state directories are ignored.
 cabalStateDir :: IO FilePath
 cabalStateDir = do
+  envCabal <- lookupEnv "CABAL_DIR"
   dotCabal <- getAppUserDataDirectory "cabal"
   dotCabalExists <- doesDirectoryExist dotCabal
-  if dotCabalExists then pure dotCabal else
-    getXdgDirectory XdgCache "cabal"
+  case envCabal of
+    Just dir -> pure dir
+    Nothing ->
+      if dotCabalExists
+      then pure dotCabal
+      else getXdgDirectory XdgCache "cabal"
 
 cabalTarballDir :: String -> IO FilePath
 cabalTarballDir repo = do

--- a/hackage-db/src/Distribution/Hackage/DB/Path.hs
+++ b/hackage-db/src/Distribution/Hackage/DB/Path.hs
@@ -17,8 +17,18 @@ import Control.Exception
 import System.Directory
 import System.FilePath
 
+-- Some logic to handle both old ~/.cabal and XDG cache directory used
+-- by default from cabal-install 3.10.1.0.
+--
+-- This is a simplified form of the logic found in cabal-install
+-- itself:
+-- https://github.com/haskell/cabal/blob/0ed12188525335ac9759dc957d49979ab09382a1/cabal-install/src/Distribution/Client/Config.hs#L594-L610
 cabalStateDir :: IO FilePath
-cabalStateDir = getAppUserDataDirectory "cabal"
+cabalStateDir = do
+  dotCabal <- getAppUserDataDirectory "cabal"
+  dotCabalExists <- doesDirectoryExist dotCabal
+  if dotCabalExists then pure dotCabal else
+    getXdgDirectory XdgCache "cabal"
 
 cabalTarballDir :: String -> IO FilePath
 cabalTarballDir repo = do


### PR DESCRIPTION
From 3.10.1.0 onwards, cabal-install uses XDG directories to store its state and cache components.  cabal2nix expects to find the Hackage tarball in ~/.cabal, where it may no longer be located.

This commit changes cabal2nix to look in ~/.cabal if that directory exists (which matches the behaviour of cabal-install itself), but otherwise looks in the appropriate XDG directory.