### PR TITLE
cabal2nix: Add graphviz and z3 to rest-rewrite test deps

### DIFF
--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -161,6 +161,7 @@ hooks =
   , ("qtah-qt5", set (libraryDepends . tool . contains (bind "pkgs.qt5.qtbase")) True)
   , ("readline", over (libraryDepends . system) (Set.union (pkgs ["readline", "ncurses"])))
   , ("req", set doCheck False)  -- test suite requires network access
+  , ("rest-rewrite", over (testDepends . system) (Set.union (pkgs ["graphviz", "z3"])))
   , ("sbv > 7", set (testDepends . system . contains (pkg "z3")) True)
   , ("sdr", set (metaSection . platforms) (Just $ Set.singleton (NixpkgsPlatformGroup (ident # "x86_64")))) -- https://github.com/adamwalker/sdr/issues/2
   , ("shake-language-c", set doCheck False) -- https://github.com/samplecount/shake-language-c/issues/26


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/240235.

This produces the derivation we want:

```diff
diff --git a/pkgs/development/haskell-modules/hackage-packages.nix b/pkgs/development/haskell-modules/hackage-packages.nix
index e5b3ee11495..4cc3ecfed70 100644
--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -250244,8 +250244,9 @@ self: {
      }) {};
 
   "rest-rewrite" = callPackage
-    ({ mkDerivation, base, containers, hashable, monad-loops, mtl
-     , parsec, process, QuickCheck, text, time, unordered-containers
+    ({ mkDerivation, base, containers, graphviz, hashable, monad-loops
+     , mtl, parsec, process, QuickCheck, text, time
+     , unordered-containers, z3
      }:
      mkDerivation {
        pname = "rest-rewrite";
@@ -250259,10 +250260,11 @@ self: {
          base containers hashable mtl QuickCheck text time
          unordered-containers
        ];
+       testSystemDepends = [ graphviz z3 ];
        doHaddock = false;
        description = "Rewriting library with online termination checking";
        license = lib.licenses.bsd3;
-     }) {};
+     }) {inherit (pkgs) graphviz; inherit (pkgs) z3;};
 
   "rest-snap" = callPackage
     ({ mkDerivation, base, base-compat, bytestring, case-insensitive
```

Thanks!