### PR TITLE
Setup tz package overrides to reference system tzdata package correctly

### DIFF
--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -174,7 +174,7 @@ hooks =
   , ("tensorflow-proto", set (libraryDepends . tool . contains (pkg "protobuf")) True)
   , ("thyme", set (libraryDepends . tool . contains (self "cpphs")) True) -- required on Darwin
   , ("twilio", set doCheck False)         -- attempts to access the network
-  , ("tz", set phaseOverrides "preConfigure = \"export TZDIR=${pkgs.tzdata}/share/zoneinfo\";")
+  , ("tz", tzOverrides)
   , ("udev", set (metaSection . platforms) (Just $ Set.singleton (NixpkgsPlatformGroup (ident # "linux"))))
   , ("websockets", set doCheck False)   -- https://github.com/jaspervdj/websockets/issues/104
   , ("Win32", set (metaSection . platforms) (Just $ Set.singleton (NixpkgsPlatformGroup (ident # "windows"))))
@@ -404,6 +404,15 @@ bustleOverrides = set (libraryDepends . pkgconfig . contains "system-glib = pkgs
                 . set (executableDepends . pkgconfig . contains "gio-unix = null") False
                 . set (metaSection . license) (Known "lib.licenses.lgpl21Plus")
                 . set (metaSection . hydraPlatforms) Nothing
+
+tzOverrides :: Derivation -> Derivation
+tzOverrides =
+  -- The tz Haskell package uses zoneinfo files from the system tzdata package in its tests.
+  set phaseOverrides "preCheck = \"export TZDIR=${system-tzdata}/share/zoneinfo\";" .
+  -- The tz Haskell package depends on both the tzdata Haskell package, as well as the
+  -- tzdata system package.  The following passes in the tzdata system package as
+  -- "system-tzdata".
+  set (testDepends . system . contains "system-tzdata = pkgs.tzdata") True
 
 nullBinding :: Identifier -> Binding
 nullBinding name = binding # (name, path # [ident # "null"])

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -174,7 +174,6 @@ hooks =
   , ("tensorflow-proto", set (libraryDepends . tool . contains (pkg "protobuf")) True)
   , ("thyme", set (libraryDepends . tool . contains (self "cpphs")) True) -- required on Darwin
   , ("twilio", set doCheck False)         -- attempts to access the network
-  , ("tz", tzOverrides)
   , ("udev", set (metaSection . platforms) (Just $ Set.singleton (NixpkgsPlatformGroup (ident # "linux"))))
   , ("websockets", set doCheck False)   -- https://github.com/jaspervdj/websockets/issues/104
   , ("Win32", set (metaSection . platforms) (Just $ Set.singleton (NixpkgsPlatformGroup (ident # "windows"))))
@@ -404,13 +403,6 @@ bustleOverrides = set (libraryDepends . pkgconfig . contains "system-glib = pkgs
                 . set (executableDepends . pkgconfig . contains "gio-unix = null") False
                 . set (metaSection . license) (Known "lib.licenses.lgpl21Plus")
                 . set (metaSection . hydraPlatforms) Nothing
-
--- | The tz Haskell package depends on both the tzdata Haskell package, as well as the
--- tzdata system package.  The following passes in the tzdata system package as
--- \"system-tzdata\".
-tzOverrides :: Derivation -> Derivation
-tzOverrides =
-  set (testDepends . system . contains "system-tzdata = pkgs.tzdata") True
 
 nullBinding :: Identifier -> Binding
 nullBinding name = binding # (name, path # [ident # "null"])

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -405,13 +405,11 @@ bustleOverrides = set (libraryDepends . pkgconfig . contains "system-glib = pkgs
                 . set (metaSection . license) (Known "lib.licenses.lgpl21Plus")
                 . set (metaSection . hydraPlatforms) Nothing
 
+-- | The tz Haskell package depends on both the tzdata Haskell package, as well as the
+-- tzdata system package.  The following passes in the tzdata system package as
+-- \"system-tzdata\".
 tzOverrides :: Derivation -> Derivation
 tzOverrides =
-  -- The tz Haskell package uses zoneinfo files from the system tzdata package in its tests.
-  set phaseOverrides "preCheck = \"export TZDIR=${system-tzdata}/share/zoneinfo\";" .
-  -- The tz Haskell package depends on both the tzdata Haskell package, as well as the
-  -- tzdata system package.  The following passes in the tzdata system package as
-  -- "system-tzdata".
   set (testDepends . system . contains "system-tzdata = pkgs.tzdata") True
 
 nullBinding :: Identifier -> Binding


### PR DESCRIPTION
This PR changes the cabal2nix hooks for the `tz` Haskell package.  Originally, the `tz` package had a hook that added a phase override for `preConfigure` that looked like the following:

```nix
preConfigure = "export TZDIR=${pkgs.tzdata}/share/zoneinfo";
```

This works for `hackage2nix`, but the problem is that when using `cabal2nix` by itself, this produces a Nix file like the following:

```nix
{ mkDerivation, base, binary, bytestring, containers, criterion
, data-default, deepseq, HUnit, lens, lib, QuickCheck, tasty
, tasty-hunit, tasty-quickcheck, tasty-th, template-haskell, thyme
, time, timezone-olson, timezone-series, tzdata, vector
}:
mkDerivation {
  pname = "tz";
  version = "0.1.3.6";
  preConfigure = "export TZDIR=${pkgs.tzdata}/share/zoneinfo";
  ...
}
```

This is trying to reference `pkgs.tzdata`, but `pkgs` is not available here!

This commit changes the hook for `tz` to take a `system-tzdata` package as an argument, and then correctly reference this `system-tzdata` for the tests:

```nix
{ mkDerivation, base, binary, bytestring, containers, criterion
, data-default, deepseq, HUnit, lens, lib, QuickCheck
, system-tzdata, tasty, tasty-hunit, tasty-quickcheck, tasty-th
, template-haskell, thyme, time, timezone-olson, timezone-series
, tzdata, vector
}:
mkDerivation {
  pname = "tz";
  version = "0.1.3.6";
  preCheck = "export TZDIR=${system-tzdata}/share/zoneinfo";
  ...
}
```
