### PR TITLE
Make hackage2nix locale independent

### DIFF
--- a/cabal2nix/CHANGELOG.md
+++ b/cabal2nix/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision History for cabal2nix
 
+## Unreleased
+
+* `hackage2nix` now defaults internally to a utf-8 locale ignoring enviroment
+  variables.
+
 ## 2.19.1
 
 **Warning**: This version of `cabal2nix` generates Nix expressions that

--- a/cabal2nix/hackage2nix/Main.hs
+++ b/cabal2nix/hackage2nix/Main.hs
@@ -41,6 +41,7 @@ import Text.PrettyPrint.HughesPJClass hiding ( (<>) )
 import Data.List.NonEmpty (NonEmpty)
 import Data.Semigroup (sconcat)
 import Options.Applicative.NonEmpty (some1)
+import GHC.IO.Encoding (setLocaleEncoding)
 
 type PackageSet = Map PackageName Version
 type PackageMultiSet = Map PackageName (Set Version)
@@ -56,6 +57,7 @@ data CLI = CLI
 
 main :: IO ()
 main = do
+  setLocaleEncoding utf8
   let cliOptions :: Parser CLI
       cliOptions = CLI
         <$> strOption (long "hackage" <> help "path to Hackage git repository" <> value "hackage" <> showDefaultWith id <> metavar "PATH")


### PR DESCRIPTION
Since my system is currently missing the locale `C.UTF-8` which we set in `regenerate-hackage-packages.nix` I want to make `hackage2nix` locale independent. The impurity is driving me nuts. Since we all edit the same file with hackage2nix hardcoding the locale makes total sense.

From memory I think the locale can affect two things:

1. It affects the encoding with which hackage-packages.nix get’s written.
2. It affects the ordering of entries in hackage-packages.nix

After reading the documentation for `base:System.IO` I am moderately certain that this change fixes 1.

Regarding 2 I am just confused. From reading the code I think the ordering depends on the Ord instances of PackageName and Version. Those are newtypes which in the end all boil down to the Ord instances of ShortByteString or String or Int or Word64. I haven’t found any indication that any of them is locale dependent, but I might have overlooked something. Or the ordering issue is something completely else? I don’t know.

At least I think setting the locale explicitly this way won’t make things less reproducible.