### PR TITLE
Terminal colors for output

### DIFF
--- a/cabal2nix/cabal2nix.cabal
+++ b/cabal2nix/cabal2nix.cabal
@@ -30,6 +30,7 @@ source-repository head
 
 library
   exposed-modules:    Cabal2nix
+                      Distribution.Nixpkgs.Color
                       Distribution.Nixpkgs.Fetch
                       Distribution.Nixpkgs.Haskell
                       Distribution.Nixpkgs.Haskell.BuildInfo
@@ -53,6 +54,7 @@ library
                     -- with all installation methods mentioned in the README!
                     , Cabal                >= 3.0
                     , aeson                > 1
+                    , ansi-terminal
                     , ansi-wl-pprint
                     , bytestring
                     , containers           >= 0.5.9

--- a/cabal2nix/src/Cabal2nix.hs
+++ b/cabal2nix/src/Cabal2nix.hs
@@ -17,6 +17,7 @@ import qualified Data.Set as Set
 import Data.String
 import Data.Time
 import Distribution.Compiler
+import Distribution.Nixpkgs.Color (colorStderrLn, warningColor)
 import Distribution.Nixpkgs.Fetch
 import Distribution.Nixpkgs.Haskell
 import Distribution.Nixpkgs.Haskell.FromCabal
@@ -36,7 +37,7 @@ import Language.Nix
 import Options.Applicative
 import Paths_cabal2nix ( version )
 import System.Environment ( getArgs )
-import System.IO ( hFlush, hPutStrLn, stdout, stderr )
+import System.IO ( hFlush, stdout, stderr )
 import qualified Text.PrettyPrint.ANSI.Leijen as P2
 import Text.PrettyPrint.HughesPJClass ( Doc, Pretty(..), text, vcat, hcat, semi, render, prettyShow )
 
@@ -188,8 +189,8 @@ cabal2nix' opts@Options{..} = do
 
 cabal2nixWithDB :: DB.HackageDB -> Options -> IO (Either Doc Derivation)
 cabal2nixWithDB db opts@Options{..} = do
-  when (isJust optHackageDb) $ hPutStrLn stderr "WARN: HackageDB provided directly; ignoring --hackage-db"
-  when (isJust optHackageSnapshot) $ hPutStrLn stderr "WARN: HackageDB provided directly; ignoring --hackage-snapshot"
+  when (isJust optHackageDb) $ colorStderrLn warningColor "WARN: HackageDB provided directly; ignoring --hackage-db"
+  when (isJust optHackageSnapshot) $ colorStderrLn warningColor "WARN: HackageDB provided directly; ignoring --hackage-snapshot"
   pkg <- getPackage' optHpack optFetchSubmodules (return db) $
          Source {
            sourceUrl = optUrl,

--- a/cabal2nix/src/Distribution/Nixpkgs/Color.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Color.hs
@@ -1,0 +1,70 @@
+module Distribution.Nixpkgs.Color
+    ( maybeColor
+    , colorStderrLn
+    , infoColor
+    , warningColor
+    , errorColor
+    , commandColor
+    ) where
+
+import System.Environment (lookupEnv)
+import System.IO (Handle, hIsTerminalDevice, hPutStrLn, stderr)
+import System.Console.ANSI.Codes
+    ( setSGRCode
+    , SGR(Reset, SetColor, SetConsoleIntensity)
+    , ConsoleLayer(Foreground)
+    , ColorIntensity(Vivid)
+    , Color(Yellow, Red, Cyan)
+    , ConsoleIntensity(BoldIntensity)
+    )
+import Control.Monad.IO.Class (MonadIO(liftIO))
+
+-- | Colors that indicate a warning message.
+warningColor :: [SGR]
+warningColor = [SetColor Foreground Vivid Yellow]
+
+infoColor :: [SGR]
+infoColor = [SetColor Foreground Vivid Cyan]
+
+-- | Colors that indicate an error message.
+errorColor :: [SGR]
+errorColor = [SetColor Foreground Vivid Red, SetConsoleIntensity BoldIntensity]
+
+-- | Colors that indicate a command is being executed.
+commandColor :: [SGR]
+commandColor = [SetColor Foreground Vivid Cyan, SetConsoleIntensity BoldIntensity]
+
+-- | Check if an environment variable is set and non-empty.
+envIsSet :: String -> IO Bool
+envIsSet name = do
+    value <- lookupEnv name
+    pure $ case value of
+       Nothing -> False
+       Just "" -> False
+       Just _ -> True
+
+-- | Should output to the given `Handle` be colored?
+shouldColor :: Handle -> IO Bool
+shouldColor handle = do
+    -- See: https://no-color.org/
+    noColor <- envIsSet "NO_COLOR"
+    if noColor
+       then pure False
+       else do
+           forceColor <- envIsSet "FORCE_COLOR"
+           if forceColor
+              then pure True
+              else hIsTerminalDevice handle
+
+-- | If the given `Handle` should be colored, wrap a `String` in `SGR` codes.
+maybeColor :: Handle -> [SGR] -> String -> IO String
+maybeColor handle sgrCodes original = do
+    shouldColor' <- shouldColor handle
+    if not shouldColor'
+       then pure original
+       else pure $ setSGRCode sgrCodes <> original <> setSGRCode [Reset]
+
+colorStderrLn :: MonadIO m => [SGR] -> String -> m ()
+colorStderrLn sgrCodes original = liftIO $ do
+    maybeColored <- maybeColor stderr sgrCodes original
+    hPutStrLn stderr maybeColored

--- a/cabal2nix/src/Distribution/Nixpkgs/Fetch.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Fetch.hs
@@ -25,12 +25,12 @@ import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BS
 import qualified Data.List as L
 import Data.Maybe
+import Distribution.Nixpkgs.Color (colorStderrLn, commandColor, warningColor)
 import GHC.Generics ( Generic )
 import Language.Nix.PrettyPrinting as PP
 import System.Directory
 import System.Environment
 import System.Exit
-import System.IO
 import System.Process
 
 -- | A source is a location from which we can fetch, such as a HTTP URL, a GIT URL, ....
@@ -219,7 +219,7 @@ derivKindFunction = \case
 fetchWith :: (Bool, DerivKind) -> Source -> MaybeT IO (DerivationSource, FilePath)
 fetchWith (supportsRev, kind) source = do
   unless ((sourceRevision source /= "") || isUnknown (sourceHash source) || not supportsRev) $
-    liftIO (hPutStrLn stderr "** need a revision for VCS when the hash is given. skipping.") >> mzero
+    colorStderrLn warningColor "** need a revision for VCS when the hash is given. skipping." >> mzero
 
   let (script, extraArgs) = case kind of
         DerivKindUrl UnpackArchive ->  ("nix-prefetch-url", ["--unpack"])
@@ -236,7 +236,7 @@ fetchWith (supportsRev, kind) source = do
          : [ sourceRevision source | supportsRev ]
          ++ hashToList (sourceHash source)
 
-  liftIO $ hPutStrLn stderr $ "$ " ++ unwords (script:args)
+  colorStderrLn commandColor $ "$ " ++ unwords (script:args)
 
   MaybeT $ liftIO $ do
     envs <- getEnvironment


### PR DESCRIPTION
This adds terminal colors to `cabal2nix`'s output. This checks if `stderr` `isatty` so that output will not be colored if (for example) `cabal2nix`'s `stderr` is being piped to a file. It also respects the `$NO_COLOR` and `$FORCE_COLOR` environment variables for toggling the output coloring (see [no-color.org](https://no-color.org/)).

A couple small changes while I was preparing this:

1. I added `nix-prefetch-scripts` to the `shell.nix` so that you can run `cabal2nix` successfully while hacking on it.
2. I added a line to print the fetcher command (like `nix-prefetch-git ...`) before we run it. This makes it a lot clearer where the errors come from, and which errors are being ignored (because we're trying another fetcher).

Example output:
<img width="806" alt="image" src="https://github.com/user-attachments/assets/d06574c0-07c8-49c9-b10e-a0ca8f0ab1c0" />