### PR TITLE
Distribution.Nixpkgs.Haskell.Derivation: remove obsolete enableSplitObjs

### DIFF
--- a/cabal2nix/cabal2nix.cabal
+++ b/cabal2nix/cabal2nix.cabal
@@ -1,5 +1,5 @@
 name:               cabal2nix
-version:            2.19.1
+version:            2.20.0
 synopsis:           Convert Cabal files into Nix build instructions.
 description:
   Convert Cabal files into Nix build instructions. Users of Nix can install the latest

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/Derivation.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/Derivation.hs
@@ -6,7 +6,7 @@
 module Distribution.Nixpkgs.Haskell.Derivation
   ( Derivation, nullDerivation, pkgid, revision, src, subpath, isLibrary, isExecutable
   , extraFunctionArgs, libraryDepends, executableDepends, testDepends, configureFlags
-  , cabalFlags, runHaddock, jailbreak, doCheck, doBenchmark, testTarget, hyperlinkSource, enableSplitObjs
+  , cabalFlags, runHaddock, jailbreak, doCheck, doBenchmark, testTarget, hyperlinkSource
   , enableLibraryProfiling, enableExecutableProfiling, phaseOverrides, editedCabalFile, metaSection
   , dependencies, setupDepends, benchmarkDepends, enableSeparateDataOutput, extraAttributes
   )
@@ -60,7 +60,6 @@ data Derivation = MkDerivation
   , _hyperlinkSource            :: Bool
   , _enableLibraryProfiling     :: Bool
   , _enableExecutableProfiling  :: Bool
-  , _enableSplitObjs            :: Bool
   , _phaseOverrides             :: String
   , _editedCabalFile            :: String
   , _enableSeparateDataOutput   :: Bool
@@ -93,7 +92,6 @@ nullDerivation = MkDerivation
   , _hyperlinkSource = error "undefined Derivation.hyperlinkSource"
   , _enableLibraryProfiling = error "undefined Derivation.enableLibraryProfiling"
   , _enableExecutableProfiling = error "undefined Derivation.enableExecutableProfiling"
-  , _enableSplitObjs = error "undefined Derivation.enableSplitObjs"
   , _phaseOverrides = error "undefined Derivation.phaseOverrides"
   , _editedCabalFile = error "undefined Derivation.editedCabalFile"
   , _enableSeparateDataOutput = error "undefined Derivation.enableSeparateDataOutput"
@@ -130,7 +128,6 @@ instance Pretty Derivation where
       , onlyIf (_benchmarkDepends /= mempty) $ pPrintBuildInfo "benchmark" _benchmarkDepends
       , boolattr "enableLibraryProfiling" _enableLibraryProfiling _enableLibraryProfiling
       , boolattr "enableExecutableProfiling" _enableExecutableProfiling _enableExecutableProfiling
-      , boolattr "enableSplitObjs"  (not _enableSplitObjs) _enableSplitObjs
       , boolattr "doHaddock" (not _runHaddock) _runHaddock
       , boolattr "jailbreak" _jailbreak _jailbreak
       , boolattr "doCheck" (not _doCheck) _doCheck

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -114,7 +114,6 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
     & doBenchmark .~ False
     & testTarget .~ mempty
     & hyperlinkSource .~ True
-    & enableSplitObjs .~ True
     & enableLibraryProfiling .~ False
     & enableExecutableProfiling .~ False
     & enableSeparateDataOutput .~ not (null dataFiles)


### PR DESCRIPTION
See https://github.com/nixOS/nixpkgs/commit/a62b24be6d650757deb8fe222763f436a53650ff