### PR TITLE
Change testTarget -> testTargets

### DIFF
--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/Derivation.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/Derivation.hs
@@ -6,7 +6,7 @@
 module Distribution.Nixpkgs.Haskell.Derivation
   ( Derivation, nullDerivation, pkgid, revision, src, subpath, isLibrary, isExecutable
   , extraFunctionArgs, libraryDepends, executableDepends, testDepends, configureFlags
-  , cabalFlags, runHaddock, jailbreak, doCheck, doBenchmark, testTarget, hyperlinkSource
+  , cabalFlags, runHaddock, jailbreak, doCheck, doBenchmark, testTargets, hyperlinkSource
   , enableLibraryProfiling, enableExecutableProfiling, phaseOverrides, editedCabalFile, metaSection
   , dependencies, setupDepends, benchmarkDepends, enableSeparateDataOutput, extraAttributes
   )
@@ -56,7 +56,7 @@ data Derivation = MkDerivation
   , _jailbreak                  :: Bool
   , _doCheck                    :: Bool
   , _doBenchmark                :: Bool
-  , _testTarget                 :: String
+  , _testTargets                :: [String]
   , _hyperlinkSource            :: Bool
   , _enableLibraryProfiling     :: Bool
   , _enableExecutableProfiling  :: Bool
@@ -88,7 +88,7 @@ nullDerivation = MkDerivation
   , _jailbreak = error "undefined Derivation.jailbreak"
   , _doCheck = error "undefined Derivation.doCheck"
   , _doBenchmark = error "undefined Derivation.doBenchmark"
-  , _testTarget = error "undefined Derivation.testTarget"
+  , _testTargets = error "undefined Derivation.testTargets"
   , _hyperlinkSource = error "undefined Derivation.hyperlinkSource"
   , _enableLibraryProfiling = error "undefined Derivation.enableLibraryProfiling"
   , _enableExecutableProfiling = error "undefined Derivation.enableExecutableProfiling"
@@ -132,7 +132,7 @@ instance Pretty Derivation where
       , boolattr "jailbreak" _jailbreak _jailbreak
       , boolattr "doCheck" (not _doCheck) _doCheck
       , boolattr "doBenchmark" _doBenchmark _doBenchmark
-      , onlyIf (not (null _testTarget)) $ attr "testTarget" $ string _testTarget
+      , onlyIf (not (null _testTargets)) $ listattr "testTargets" empty (map show _testTargets)
       , boolattr "hyperlinkSource" (not _hyperlinkSource) _hyperlinkSource
       , onlyIf (not (null _phaseOverrides)) $ vcat ((map text . lines) _phaseOverrides)
       , pPrint _metaSection

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -112,7 +112,7 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
     & jailbreak .~ False
     & doCheck .~ True
     & doBenchmark .~ False
-    & testTarget .~ mempty
+    & testTargets .~ mempty
     & hyperlinkSource .~ True
     & enableLibraryProfiling .~ False
     & enableExecutableProfiling .~ False

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -89,7 +89,7 @@ hooks =
   , ("darcs", set phaseOverrides darcsInstallPostInstall . set doCheck False)
   , ("dbus", set doCheck False) -- don't execute tests that try to access the network
   , ("dhall", set doCheck False) -- attempts to access the network
-  , ("dns", set testTarget "spec")      -- don't execute tests that try to access the network
+  , ("dns", set testTargets ["spec"])      -- don't execute tests that try to access the network
   , ("eventstore", set (metaSection . platforms) (Just $ Set.singleton (NixpkgsPlatformGroup (ident # "x86_64"))))
   , ("freenect < 1.2.1", over configureFlags (Set.union (Set.fromList ["--extra-include-dirs=${lib.getDev pkgs.freenect}/include/libfreenect", "--extra-lib-dirs=${lib.getLib pkgs.freenect}/lib"])))
   , ("fltkhs", set (libraryDepends . system . contains (pkg "fltk14")) True . over (libraryDepends . pkgconfig) (Set.union (pkgs ["libGLU", "libGL"]))) -- TODO: fltk14 belongs into the *setup* dependencies.
@@ -123,7 +123,7 @@ hooks =
   , ("hlibgit2 >= 0.18.0.14", set (testDepends . tool . contains (pkg "git")) True)
   , ("hmatrix < 0.18.1.1", set phaseOverrides "preConfigure = \"sed -i hmatrix.cabal -e '/\\\\/usr\\\\//D'\";")
   , ("holy-project", set doCheck False)         -- attempts to access the network
-  , ("hoogle", set testTarget "--test-option=--no-net")
+  , ("hoogle", set testTargets ["--test-option=--no-net"])
   , ("hsignal < 0.2.7.4", set phaseOverrides "prePatch = \"rm -v Setup.lhs\";") -- https://github.com/amcphail/hsignal/issues/1
   , ("hslua < 0.9.3", over (libraryDepends . system) (replace (pkg "lua") (pkg "lua5_1")))
   , ("hslua >= 0.9.3 && < 2.0.0", over (libraryDepends . system) (replace (pkg "lua") (pkg "lua5_3")))
@@ -334,7 +334,7 @@ opencvOverrides = set phaseOverrides "hardeningDisable = [ \"bindnow\" ];"
                 . over (libraryDepends . pkgconfig) (replace (pkg "opencv") (pkg "opencv3"))
 
 hspecCoreOverrides :: Derivation -> Derivation   -- https://github.com/hspec/hspec/issues/330
-hspecCoreOverrides = set phaseOverrides "testTarget = \"--test-option=--skip --test-option='Test.Hspec.Core.Runner.hspecResult runs specs in parallel'\";"
+hspecCoreOverrides = set phaseOverrides "testTargets = [ \"--test-option=--skip\" \"--test-option='Test.Hspec.Core.Runner.hspecResult runs specs in parallel'\" ];"
 
 cabal2nixOverrides :: Derivation -> Derivation
 cabal2nixOverrides = set phaseOverrides $ unlines

--- a/cabal2nix/test/golden-test-cases/hoogle.nix.golden
+++ b/cabal2nix/test/golden-test-cases/hoogle.nix.golden
@@ -23,7 +23,7 @@ mkDerivation {
     warp-tls zlib
   ];
   executableHaskellDepends = [ base ];
-  testTarget = "--test-option=--no-net";
+  testTargets = [ "--test-option=--no-net" ];
   homepage = "http://hoogle.haskell.org/";
   description = "Haskell API Search";
   license = lib.licenses.bsd3;


### PR DESCRIPTION
We refactor testTarget from an unstructured string, to a list of strings representing testTargets.

See the corresponding nixpkgs PR: https://github.com/NixOS/nixpkgs/pull/306283/files