### PR TITLE
Fix `cannot replace name binding ... Identifier "null"`

### DIFF
--- a/cabal2nix/src/Cabal2nix.hs
+++ b/cabal2nix/src/Cabal2nix.hs
@@ -32,6 +32,7 @@ import Distribution.PackageDescription ( mkFlagName, mkFlagAssignment, FlagAssig
 import Distribution.Parsec as P
 import Distribution.Simple.Utils ( lowercase )
 import Distribution.System
+import GHC.Stack (HasCallStack)
 import Language.Nix
 import Options.Applicative
 import Paths_cabal2nix ( version )
@@ -165,7 +166,7 @@ pinfo = info
                      ]))
         )
 
-main :: IO ()
+main :: HasCallStack => IO ()
 main = bracket (return ()) (\() -> hFlush stdout >> hFlush stderr) $ \() ->
   cabal2nix =<< getArgs
 
@@ -173,7 +174,7 @@ hpackOverrides :: Derivation -> Derivation
 hpackOverrides = over phaseOverrides (++ "prePatch = \"hpack\";")
                . set (libraryDepends . tool . contains (PP.pkg "hpack")) True
 
-cabal2nix' :: Options -> IO (Either Doc Derivation)
+cabal2nix' :: HasCallStack => Options -> IO (Either Doc Derivation)
 cabal2nix' opts@Options{..} = do
   pkg <- getPackage optHpack optFetchSubmodules optHackageDb optHackageSnapshot $
          Source {
@@ -201,7 +202,7 @@ cabal2nixWithDB db opts@Options{..} = do
          }
   processPackage opts pkg
 
-processPackage :: Options -> Package -> IO (Either Doc Derivation)
+processPackage :: HasCallStack => Options -> Package -> IO (Either Doc Derivation)
 processPackage Options{..} pkg = do
   let
       withHpackOverrides :: Derivation -> Derivation
@@ -255,7 +256,7 @@ processPackage Options{..} pkg = do
               ]
   pure $ if optNixShellOutput then Left shell else Right deriv
 
-cabal2nix :: [String] -> IO ()
+cabal2nix :: HasCallStack => [String] -> IO ()
 cabal2nix = parseArgs >=> cabal2nix' >=> putStrLn . either render prettyShow
 
 parseArgs :: [String] -> IO Options

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -35,12 +35,13 @@ import Distribution.Types.PkgconfigDependency as Cabal
 import Distribution.Types.UnqualComponentName as Cabal
 import Distribution.Utils.ShortText ( fromShortText )
 import Distribution.Version
+import GHC.Stack (HasCallStack)
 import Language.Nix
 
 type HaskellResolver = PackageVersionConstraint -> Bool
 type NixpkgsResolver = Identifier -> Maybe Binding
 
-fromGenericPackageDescription :: HaskellResolver -> NixpkgsResolver -> Platform -> CompilerInfo -> FlagAssignment -> [Constraint] -> GenericPackageDescription -> Derivation
+fromGenericPackageDescription :: HasCallStack => HaskellResolver -> NixpkgsResolver -> Platform -> CompilerInfo -> FlagAssignment -> [Constraint] -> GenericPackageDescription -> Derivation
 fromGenericPackageDescription haskellResolver nixpkgsResolver arch compiler flags constraints genDesc =
   fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags descr
     where
@@ -92,7 +93,7 @@ finalizeGenericPackageDescription haskellResolver arch compiler flags constraint
                 Right (d,_) -> (d,m)
     Right (d,_)  -> (d,[])
 
-fromPackageDescription :: HaskellResolver -> NixpkgsResolver -> [Dependency] -> FlagAssignment -> PackageDescription -> Derivation
+fromPackageDescription :: HasCallStack => HaskellResolver -> NixpkgsResolver -> [Dependency] -> FlagAssignment -> PackageDescription -> Derivation
 fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags PackageDescription {..} = normalize $ postProcess $ nullDerivation
     & isLibrary .~ isJust library
     & pkgid .~ package

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -382,4 +382,4 @@ bustleOverrides = set (libraryDepends . pkgconfig . contains "system-glib = pkgs
                 . set (metaSection . hydraPlatforms) Nothing
 
 nullBinding :: Identifier -> Binding
-nullBinding name = binding # (name, path # [ident # "null"])
+nullBinding name = binding # (name, path # ["pkgs", name])


### PR DESCRIPTION
This is the error I encountered:

```
cabal2nix: post-process: cannot replace name binding Bind (Identifier "gstreamer") (Path [Identifier "null"]) by Bind (Identifier "gstreamer") (Path [Identifier "pkgs",Identifier "gst_all_1",Identifier "gstrea>
CallStack (from HasCallStack):
  error, called at src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs:211:27 in cabal2nix-2.19.1-2Xhk8y7AoxGDHZPBS0CWBa:Distribution.Nixpkgs.Haskell.FromCabal.PostProcess
```

The second commit fixes it. I in fact don't understand this code and why this commit fixes it :) I use this version of cabal2nix for a personal project with ton of (indirect) dependencies, so it seems like it didn't break anything.

The first commit adds `HasCallStack` that I used in hope to understand what's going on here. I've left it in because I felt that callstack is really useful for exception.