### PR TITLE
FromCabal.PostProcess: remove apple_sdk frameworks for hfsevents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ TAGS
 .stack-work
 /*/src/highlight.js
 /*/src/style.css
+
+.direnv

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -320,8 +320,6 @@ hfseventsOverrides :: Derivation -> Derivation
 hfseventsOverrides
   = set isLibrary True
   . set (metaSection . platforms) (Just $ Set.singleton (NixpkgsPlatformGroup (ident # "darwin")))
-  . set (libraryDepends . tool . contains (bind "pkgs.darwin.apple_sdk.frameworks.CoreServices")) True
-  . set (libraryDepends . system . contains (bind "pkgs.darwin.apple_sdk.frameworks.Cocoa")) True
   . over (libraryDepends . haskell) (Set.union (Set.fromList (map bind ["self.base", "self.cereal", "self.mtl", "self.text", "self.bytestring"])))
 
 opencvOverrides :: Derivation -> Derivation


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/400565 / https://github.com/NixOS/nixpkgs/pull/398707 for rationale.