### PR TITLE
.github: run on ubuntu-24.04

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20241121
+# version: 0.19.20250330
 #
-# REGENDATA ("0.19.20241121",["--branches","master","--github-patches",".github/workflows/ci-skip-package-map.patch","--doctest","--doctest-options=-i ../../dist-newstyle/build/*/*/cabal2nix-*/build/autogen","--doctest-jobs=>= 8.8 && < 9.4","github","cabal.project"])
+# REGENDATA ("0.19.20250330",["--branches","master","--github-patches",".github/workflows/ci-skip-package-map.patch","--doctest","--doctest-options=-i ../../dist-newstyle/build/*/*/cabal2nix-*/build/autogen","--doctest-jobs=>= 8.8 && < 9.4","github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,7 +23,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -76,12 +76,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1-p1 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1-p1 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -164,7 +164,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache/restore@v4
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-fb82843d
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-16fa4f55
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -183,7 +183,7 @@ jobs:
         if: always()
         uses: actions/cache/save@v4
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-fb82843d
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-16fa4f55
           path: ~/.haskell-ci-tools
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -37,14 +37,14 @@ jobs:
             compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.8.3
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.8.3
-            setup-method: ghcup-vanilla
+            compilerVersion: 9.8.4
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -86,20 +86,6 @@ jobs:
         if: matrix.setup-method == 'ghcup'
         run: |
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
-      - name: Install GHC (GHCup vanilla)
-        if: matrix.setup-method == 'ghcup-vanilla'
-        run: |
-          "$HOME/.ghcup/bin/ghcup" -s https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-vanilla-0.0.8.yaml install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
           HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')

--- a/cabal2nix/cabal2nix.cabal
+++ b/cabal2nix/cabal2nix.cabal
@@ -12,7 +12,7 @@ author:             Peter Simons <simons@cryp.to>
 -- list all contributors: git log --pretty='%an' | sort | uniq
 maintainer:         sternenseemann <sternenseemann@systemli.org>
 stability:          stable
-tested-with:        GHC == 8.10.7 || == 9.0.2 || == 9.2.8 || == 9.4.8 || == 9.6.6 || == 9.8.3 || == 9.10.1
+tested-with:        GHC == 8.10.7 || == 9.0.2 || == 9.2.8 || == 9.4.8 || == 9.6.7 || == 9.8.4 || == 9.10.1
 category:           Distribution, Nix
 homepage:           https://github.com/nixos/cabal2nix#readme
 bug-reports:        https://github.com/nixos/cabal2nix/issues

--- a/distribution-nixpkgs/distribution-nixpkgs.cabal
+++ b/distribution-nixpkgs/distribution-nixpkgs.cabal
@@ -6,7 +6,7 @@ license:       BSD3
 license-file:  LICENSE
 author:        Peter Simons <simons@cryp.to>
 maintainer:    sternenseemann <sternenseemann@systemli.org>
-tested-with:   GHC == 8.10.7 || == 9.0.2 || == 9.2.8 || == 9.4.8 || == 9.6.6 || == 9.8.3 || == 9.10.1
+tested-with:   GHC == 8.10.7 || == 9.0.2 || == 9.2.8 || == 9.4.8 || == 9.6.7 || == 9.8.4 || == 9.10.1
 category:      Distribution, Nix
 homepage:      https://github.com/NixOS/cabal2nix/tree/master/distribution-nixpkgs#readme
 bug-reports:   https://github.com/NixOS/cabal2nix/issues

--- a/hackage-db/hackage-db.cabal
+++ b/hackage-db/hackage-db.cabal
@@ -9,7 +9,7 @@ license:       BSD3
 license-file:  LICENSE
 author:        Peter Simons, Alexander Altman, Ben James, Kevin Quick
 maintainer:    sternenseemann <sternenseemann@systemli.org>
-tested-with:   GHC == 8.10.7 || == 9.0.2 || == 9.2.8 || == 9.4.8 || == 9.6.6 || == 9.8.3 || == 9.10.1
+tested-with:   GHC == 8.10.7 || == 9.0.2 || == 9.2.8 || == 9.4.8 || == 9.6.7 || == 9.8.4 || == 9.10.1
 category:      Distribution
 homepage:      https://github.com/NixOS/cabal2nix/tree/master/hackage-db#readme
 bug-reports:   https://github.com/NixOS/cabal2nix/issues

--- a/hackage-db/hackage-db.cabal
+++ b/hackage-db/hackage-db.cabal
@@ -20,7 +20,7 @@ extra-doc-files:    README.md
 
 source-repository head
   type:     git
-  location: git://github.com/NixOS/cabal2nix.git
+  location: https://github.com/NixOS/cabal2nix.git
   subdir:   hackage-db
 
 flag install-examples

--- a/language-nix/language-nix.cabal
+++ b/language-nix/language-nix.cabal
@@ -7,7 +7,7 @@ license:       BSD3
 license-file:  LICENSE
 author:        Peter Simons
 maintainer:    simons@cryp.to
-tested-with:   GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.8, GHC == 9.6.6 || == 9.8.3 || == 9.10.1
+tested-with:   GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.8, GHC == 9.6.7 || == 9.8.4 || == 9.10.1
 category:      Distribution, Language, Nix
 homepage:      https://github.com/NixOS/cabal2nix/tree/master/language-nix#readme
 bug-reports:   https://github.com/NixOS/cabal2nix/issues


### PR DESCRIPTION
The ubuntu-20.04 runners have been deprecated and disabled.

Side note: A bit annoying, that `haskell-ci` is so outdated on hackage and thus in nixpkgs. The dev shell for cabal2nix provides it, but it's way too old, so I had to build it from source. Tried updating it in nixpkgs to an unstable version, but didn't succeed, yet.