### PR TITLE
Remove broken liquid-fixpoint

### DIFF
--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs
@@ -46,7 +46,6 @@ configureCabalFlags' (PackageIdentifier name version)
                                 = [enable "system-lua", disable "use-pkgconfig"]
  | name == "idris"              = [enable "gmp", enable "ffi", enable "curses", ("execonly", version `withinRange` orLaterVersion (mkVersion [1,1,1])) ]
  | name == "io-streams"         = [enable "NoInteractiveTests"]
- | name == "liquid-fixpoint"    = [enable "build-external"]
  | name == "lua" && version >= mkVersion [2,0,0]
                                 = [enable "system-lua", disable "use-pkgconfig"]
  | name == "pandoc"             = [disable "trypandoc"]

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/PostProcess.hs
@@ -137,7 +137,6 @@ hooks =
   , ("js-jquery", set doCheck False)            -- attempts to access the network
   , ("libconfig", over (libraryDepends . system) (replace "config = null" (pkg "libconfig")))
   , ("libxml", set (configureFlags . contains "--extra-include-dir=${lib.getDev libxml2}/include/libxml2") True)
-  , ("liquid-fixpoint", set (testDepends . system . contains (pkg "z3")) True . set (testDepends . system . contains (pkg "nettools")) True . set (testDepends . system . contains (pkg "git")) True . set doCheck False)
   , ("liquidhaskell", set (testDepends . system . contains (pkg "z3")) True)
   , ("lua >= 2.0.0 && < 2.2.0", over (libraryDepends . system) (replace (pkg "lua") (pkg "lua5_3")))
   , ("lua >= 2.2.0", over (libraryDepends . system) (replace (pkg "lua") (pkg "lua5_4")))


### PR DESCRIPTION
The package is broken and has a dependency on nettools, which I want to
rename in https://github.com/NixOS/nixpkgs/pull/416056
