### PR TITLE
remove cases where cabal2nix produces a stringy license

### DIFF
--- a/cabal2nix/CHANGELOG.md
+++ b/cabal2nix/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision History for cabal2nix
 
+## Upcomming
+
+* Complex licenses now make use of the compound license system added in [nixpkgs#468378](https://github.com/NixOS/nixpkgs/pull/468378).
+* Most licenses that where previously represented as strings are now show as a generic free license.
+
 ## 2.21.3
 
 * Add `--src-expression` flag to `cabal2nix` which allows overriding

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs
@@ -157,7 +157,7 @@ fromPackageDescription haskellResolver nixpkgsResolver missingDeps flags Package
                      & Nix.license .~ nixLicense
                      & Nix.platforms .~ Nothing
                      & Nix.badPlatforms .~ Nothing
-                     & Nix.hydraPlatforms .~ (if isFreeLicense nixLicense then Nothing else Just Set.empty)
+                     & Nix.hydraPlatforms .~ Nothing
                      & Nix.mainProgram .~ nixMainProgram
                      & Nix.maintainers .~ mempty
                      & Nix.broken .~ not (null missingDeps)

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -41,7 +41,7 @@ fromCabalLicense AllRightsReserved                         = Known "lib.licenses
 fromCabalLicense (Apache Nothing)                          = Known "lib.licenses.asl20"
 fromCabalLicense (Apache (Just (versionNumbers -> [2,0]))) = Known "lib.licenses.asl20"
 fromCabalLicense ISC                                       = Known "lib.licenses.isc"
-fromCabalLicense OtherLicense                              = Unknown Nothing
+fromCabalLicense OtherLicense                              = Known "[ ]"
 fromCabalLicense (UnknownLicense "CC0-1.0")                = Known "lib.licenses.cc0"
 fromCabalLicense (UnknownLicense "BSD3ClauseORApache20")   = Known "lib.licenses.bsd3"
 fromCabalLicense l                                         = error $ "Distribution.Nixpkgs.Haskell.FromCabal.License.fromCabalLicense: unknown license"
@@ -63,7 +63,7 @@ fromSPDXExpression (SPDX.EAnd expres1 expres2) = Known ("lib.licenses.AND [ (" +
 fromSPDXExpression (SPDX.EOr expres1 expres2) = Known ("lib.licenses.AND [ (" ++ NPP.prettyShow (fromSPDXExpression expres1) ++ ") (" ++ NPP.prettyShow (fromSPDXExpression expres2) ++ ") ]")
 
 fromSPDXLicense :: SPDX.License -> Distribution.Nixpkgs.License.License
-fromSPDXLicense SPDX.NONE = Unknown Nothing
+fromSPDXLicense SPDX.NONE = Known "[ ]"
 fromSPDXLicense (SPDX.License expr) = fromSPDXExpression expr
 
 -- "isFreeLicense" is used to determine whether we generate a "hydraPlatforms =

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -43,7 +43,7 @@ fromCabalLicense (Apache (Just (versionNumbers -> [2,0]))) = Known "lib.licenses
 fromCabalLicense ISC                                       = Known "lib.licenses.isc"
 fromCabalLicense OtherLicense                              = Known "[ ]"
 fromCabalLicense (UnknownLicense "CC0-1.0")                = Known "lib.licenses.cc0"
-fromCabalLicense (UnknownLicense "BSD3ClauseORApache20")   = Known "lib.licenses.bsd3"
+fromCabalLicense (UnknownLicense "BSD3ClauseORApache20")   = Known "lib.licenses.OR [ lib.licenses.bsd3 lib.licenses.asl20 ]"
 fromCabalLicense l                                         = error $ "Distribution.Nixpkgs.Haskell.FromCabal.License.fromCabalLicense: unknown license"
                                                                   ++ show l ++"\nChoose one of: " ++ intercalate ", " (map display knownLicenses)
 

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -9,7 +9,8 @@ module Distribution.Nixpkgs.Haskell.FromCabal.License
 import Data.List (intercalate)
 import Distribution.License ( License(..), knownLicenses )
 import Distribution.Nixpkgs.License
-import Distribution.Pretty (prettyShow)
+import Distribution.Pretty as DP
+import Language.Nix.PrettyPrinting as NPP
 import qualified Distribution.SPDX as SPDX
 import Distribution.Text (display)
 import Distribution.Version
@@ -46,23 +47,24 @@ fromCabalLicense (UnknownLicense "BSD3ClauseORApache20")   = Known "lib.licenses
 fromCabalLicense l                                         = error $ "Distribution.Nixpkgs.Haskell.FromCabal.License.fromCabalLicense: unknown license"
                                                                   ++ show l ++"\nChoose one of: " ++ intercalate ", " (map display knownLicenses)
 
+-- FIXME(@sternenseemann): this is not exactly Known, but a best effort lookup
+fromSPDXExpression :: SPDX.LicenseExpression -> Distribution.Nixpkgs.License.License
+fromSPDXExpression (SPDX.ELicense simpl Nothing) =
+  case simpl of
+    SPDX.ELicenseId lid -> Known ("lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow lid ++ "\"")
+    SPDX.ELicenseIdPlus lid -> Known ("lib.licenses.PLUS (lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow lid ++ "\")")
+    SPDX.ELicenseRef lid -> Known ("lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow lid ++ "\"")
+fromSPDXExpression (SPDX.ELicense simpl (Just excep)) = 
+  case simpl of
+    SPDX.ELicenseId lid -> Known ("lib.licenses.WITH (lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow lid ++ "\") (lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow excep ++ "\")")
+    SPDX.ELicenseIdPlus lid -> Known ("lib.licenses.WITH (lib.licenses.PLUS (lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow lid ++ "\")) (lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow excep ++ "\")")
+    SPDX.ELicenseRef lid -> Known ("lib.licenses.WITH (lib.licenses.PLUS (lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow lid ++ "\")) (lib.meta.getLicenseFromSpdxId \"" ++ DP.prettyShow excep ++ "\")")
+fromSPDXExpression (SPDX.EAnd expres1 expres2) = Known ("lib.licenses.AND [ (" ++ NPP.prettyShow (fromSPDXExpression expres1) ++ ") (" ++ NPP.prettyShow (fromSPDXExpression expres2) ++ ") ]")
+fromSPDXExpression (SPDX.EOr expres1 expres2) = Known ("lib.licenses.AND [ (" ++ NPP.prettyShow (fromSPDXExpression expres1) ++ ") (" ++ NPP.prettyShow (fromSPDXExpression expres2) ++ ") ]")
+
 fromSPDXLicense :: SPDX.License -> Distribution.Nixpkgs.License.License
 fromSPDXLicense SPDX.NONE = Unknown Nothing
-fromSPDXLicense (SPDX.License expr) =
-  case expr of
-    SPDX.ELicense simpl Nothing ->
-      -- Not handled: license exceptions
-      case simpl of
-        -- FIXME(@sternenseemann): this is not exactly Known, but a best effort lookup
-        SPDX.ELicenseId lid -> Known ("lib.meta.getLicenseFromSpdxId \"" ++ prettyShow lid ++ "\"")
-        _ ->
-          -- Not handed: the '+' suffix and user-defined licences references.
-          -- Use the SPDX expression as a free-form license string.
-          Unknown (Just $ prettyShow expr)
-    _ ->
-      -- Not handled: compound expressions, not expressible in Nixpkgs.
-      -- Use the SPDX expression as a free-form license string.
-      Unknown (Just $ prettyShow expr)
+fromSPDXLicense (SPDX.License expr) = fromSPDXExpression expr
 
 -- "isFreeLicense" is used to determine whether we generate a "hydraPlatforms =
 -- none" in the hackage2nix output for a package with the given license.

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/License.hs
@@ -18,16 +18,16 @@ import Distribution.Version
 -- TODO: Programmatically strip trailing zeros from license version numbers.
 
 fromCabalLicense :: Distribution.License.License -> Distribution.Nixpkgs.License.License
-fromCabalLicense (GPL Nothing)                             = Unknown (Just "GPL")
+fromCabalLicense (GPL Nothing)                             = Known "lib.licenses.free"
 fromCabalLicense (GPL (Just (versionNumbers -> [2])))      = Known "lib.licenses.gpl2Only"
 fromCabalLicense (GPL (Just (versionNumbers -> [3])))      = Known "lib.licenses.gpl3Only"
 fromCabalLicense (GPL (Just (versionNumbers -> [3,0])))    = Known "lib.licenses.gpl3Only"
-fromCabalLicense (LGPL Nothing)                            = Unknown (Just "LGPL")
+fromCabalLicense (LGPL Nothing)                            = Known "lib.licenses.free"
 fromCabalLicense (LGPL (Just (versionNumbers -> [2,1])))   = Known "lib.licenses.lgpl21Only"
 fromCabalLicense (LGPL (Just (versionNumbers -> [2])))     = Known "lib.licenses.lgpl2Only"
 fromCabalLicense (LGPL (Just (versionNumbers -> [3])))     = Known "lib.licenses.lgpl3Only"
 fromCabalLicense (LGPL (Just (versionNumbers -> [3,0])))   = Known "lib.licenses.lgpl3Only"
-fromCabalLicense (AGPL Nothing)                            = Unknown (Just "AGPL")
+fromCabalLicense (AGPL Nothing)                            = Known "lib.licenses.free"
 fromCabalLicense (AGPL (Just (versionNumbers -> [3])))     = Known "lib.licenses.agpl3Only"
 fromCabalLicense (AGPL (Just (versionNumbers -> [3,0])))   = Known "lib.licenses.agpl3Only"
 fromCabalLicense (MPL (versionNumbers ->  [2,0]))          = Known "lib.licenses.mpl20"

--- a/cabal2nix/test/golden-test-cases/HTF.nix.golden
+++ b/cabal2nix/test/golden-test-cases/HTF.nix.golden
@@ -27,6 +27,6 @@ mkDerivation {
   ];
   homepage = "https://github.com/skogsbaer/HTF/";
   description = "The Haskell Test Framework";
-  license = "LGPL";
+  license = lib.licenses.free;
   mainProgram = "htfpp";
 }

--- a/cabal2nix/test/golden-test-cases/bioalign.nix.golden
+++ b/cabal2nix/test/golden-test-cases/bioalign.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base biocore bytestring ];
   homepage = "https://patch-tag.com/r/dfornika/biophd/home";
   description = "Data structures and helper functions for calculating alignments";
-  license = "GPL";
+  license = lib.licenses.free;
 }

--- a/cabal2nix/test/golden-test-cases/ede.nix.golden
+++ b/cabal2nix/test/golden-test-cases/ede.nix.golden
@@ -20,5 +20,5 @@ mkDerivation {
   ];
   homepage = "http://github.com/brendanhay/ede";
   description = "Templating language with similar syntax and features to Liquid or Jinja2";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-adexchange-buyer.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-adexchange-buyer.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Ad Exchange Buyer SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-admin-emailmigration.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-admin-emailmigration.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Email Migration API v2 SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-affiliates.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-affiliates.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Affiliate Network SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-apps-tasks.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-apps-tasks.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Tasks SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-appstate.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-appstate.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google App State SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-blogger.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-blogger.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Blogger SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-datastore.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-datastore.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Cloud Datastore SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-dfareporting.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-dfareporting.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google DCM/DFA Reporting And Trafficking SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-firebase-rules.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-firebase-rules.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Firebase Rules SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-gmail.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-gmail.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Gmail SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-kgsearch.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-kgsearch.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Knowledge Graph Search SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-maps-engine.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-maps-engine.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Maps Engine SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-plus.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-plus.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google + SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-resourceviews.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-resourceviews.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Compute Engine Instance Groups SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-translate.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-translate.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Translate SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-webmaster-tools.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-webmaster-tools.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google Search Console SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/gogol-youtube.nix.golden
+++ b/cabal2nix/test/golden-test-cases/gogol-youtube.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base gogol-core ];
   homepage = "https://github.com/brendanhay/gogol";
   description = "Google YouTube Data SDK";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/highlighting-kate.nix.golden
+++ b/cabal2nix/test/golden-test-cases/highlighting-kate.nix.golden
@@ -18,5 +18,5 @@ mkDerivation {
   ];
   homepage = "http://github.com/jgm/highlighting-kate";
   description = "Syntax highlighting";
-  license = "GPL";
+  license = lib.licenses.free;
 }

--- a/cabal2nix/test/golden-test-cases/hxt-expat.nix.golden
+++ b/cabal2nix/test/golden-test-cases/hxt-expat.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base bytestring hexpat hxt ];
   homepage = "http://www.fh-wedel.de/~si/HXmlToolbox/index.html";
   description = "Expat parser for HXT";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/hxt-tagsoup.nix.golden
+++ b/cabal2nix/test/golden-test-cases/hxt-tagsoup.nix.golden
@@ -10,5 +10,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/UweSchmidt/hxt";
   description = "TagSoup parser for HXT";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/incremental-parser.nix.golden
+++ b/cabal2nix/test/golden-test-cases/incremental-parser.nix.golden
@@ -14,5 +14,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/blamario/incremental-parser";
   description = "Generic parser library capable of providing partial results from partial input";
-  license = "GPL";
+  license = lib.licenses.free;
 }

--- a/cabal2nix/test/golden-test-cases/lambdabot-social-plugins.nix.golden
+++ b/cabal2nix/test/golden-test-cases/lambdabot-social-plugins.nix.golden
@@ -10,5 +10,5 @@ mkDerivation {
   ];
   homepage = "https://wiki.haskell.org/Lambdabot";
   description = "Social plugins for Lambdabot";
-  license = "GPL";
+  license = lib.licenses.free;
 }

--- a/cabal2nix/test/golden-test-cases/openpgp-asciiarmor.nix.golden
+++ b/cabal2nix/test/golden-test-cases/openpgp-asciiarmor.nix.golden
@@ -14,5 +14,5 @@ mkDerivation {
   ];
   homepage = "http://floss.scru.org/openpgp-asciiarmor";
   description = "OpenPGP (RFC4880) ASCII Armor codec";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/polynomials-bernstein.nix.golden
+++ b/cabal2nix/test/golden-test-cases/polynomials-bernstein.nix.golden
@@ -5,5 +5,5 @@ mkDerivation {
   sha256 = "deadbeef";
   libraryHaskellDepends = [ base vector ];
   description = "A solver for systems of polynomial equations in bernstein form";
-  license = "GPL";
+  license = lib.licenses.free;
 }

--- a/cabal2nix/test/golden-test-cases/readline.nix.golden
+++ b/cabal2nix/test/golden-test-cases/readline.nix.golden
@@ -6,5 +6,5 @@ mkDerivation {
   libraryHaskellDepends = [ base process ];
   librarySystemDepends = [ ncurses readline ];
   description = "An interface to the GNU readline library";
-  license = "GPL";
+  license = lib.licenses.free;
 }

--- a/cabal2nix/test/golden-test-cases/swagger.nix.golden
+++ b/cabal2nix/test/golden-test-cases/swagger.nix.golden
@@ -10,5 +10,5 @@ mkDerivation {
   ];
   testHaskellDepends = [ aeson base bytestring tasty tasty-hunit ];
   description = "Implementation of swagger data model";
-  license = "unknown";
+  license = [ ];
 }

--- a/cabal2nix/test/golden-test-cases/texmath.nix.golden
+++ b/cabal2nix/test/golden-test-cases/texmath.nix.golden
@@ -17,5 +17,5 @@ mkDerivation {
   ];
   homepage = "http://github.com/jgm/texmath";
   description = "Conversion between formats used to represent mathematics";
-  license = "GPL";
+  license = lib.licenses.free;
 }

--- a/cabal2nix/test/golden-test-cases/vivid-supercollider.nix.golden
+++ b/cabal2nix/test/golden-test-cases/vivid-supercollider.nix.golden
@@ -13,5 +13,5 @@ mkDerivation {
     vivid-osc
   ];
   description = "Implementation of SuperCollider server specifications";
-  license = "GPL";
+  license = lib.licenses.free;
 }


### PR DESCRIPTION
I'm working on removing all stringy licenses in nixpkgs, and currently the only ones left are the ones in haskellPackages ~and node2nix packages~. This change fixes the ones for Haskell packages. 