### PR TITLE
language-nix: check that needsQuoting is True for NUL bytes

### DIFF
--- a/language-nix/test/hspec.hs
+++ b/language-nix/test/hspec.hs
@@ -54,6 +54,10 @@ main = hspec $ do
       it "if string contains spaces" $ stringIdentProperty $ \s ->
         any isSpace s ==> needsQuoting s
       it "if length is zero" $ shouldSatisfy "" needsQuoting
+      -- c.f. https://github.com/NixOS/cabal2nix/issues/718
+      it "if string contains a NUL byte" $ do
+        shouldSatisfy "hello\NUL world" needsQuoting
+        shouldSatisfy "\NUL" needsQuoting
 
     describe "nix-instantiate" $ do
       nixInstantiate <- runIO $ do


### PR DESCRIPTION
Emitting unquoted NUL bytes would render the output of language-nix unparseable. Quoting NUL bytes behaves in strange ways in practice (C++ Nix truncates the identifiers at the NUL byte which is not what we would expect) which is documented, but it's better than having completely invalid output.