### PR TITLE
Check `nix-instantiate` exit code in

### DIFF
--- a/distribution-nixpkgs/src/Distribution/Nixpkgs/PackageMap.hs
+++ b/distribution-nixpkgs/src/Distribution/Nixpkgs/PackageMap.hs
@@ -16,6 +16,7 @@ import Data.Set ( Set )
 import qualified Data.Set as Set
 import Language.Nix
 import Paths_distribution_nixpkgs (getDataFileName)
+import System.Exit (ExitCode(..))
 import System.Process
 
 type PackageMap = Map Identifier (Set Path)
@@ -52,10 +53,15 @@ readNixpkgSet nixpkgsPath nixpkgsArgs = do
         , "--arg", "nixpkgsPath", nixpkgsPath
         , "--arg", "nixpkgsArgs", fromMaybe "{}" nixpkgsArgs
         ]
-  (_, Just h, _, _) <- -- TODO: ensure that overrides don't screw up our results
+  (_, Just h, _, ph) <- -- TODO: ensure that overrides don't screw up our results
     createProcess nixInstantiate { std_out = CreatePipe, env = Nothing }
   buf <- LBS.hGetContents h
-  either fail return $ JSON.eitherDecode buf
+  exitCode <- waitForProcess ph
+  case exitCode of
+    ExitSuccess ->
+      either fail return $ JSON.eitherDecode buf
+    ExitFailure code ->
+      fail $ "nix-instantiate failed with exit code " ++ show code
 
 identifierSet2PackageMap :: Set [String] -> PackageMap
 identifierSet2PackageMap = foldr insertIdentifier Map.empty


### PR DESCRIPTION
`readNixpkgSet` runs `nix-instantiate --strict ...` to obtain the package map for nixpkgs.

Previously, if `nix-instantiate` failed(for example, due to the absense of Nix CLI tools), the error was silently ignored, and the function returned an empty set.

This change checks the process exit code and reports failures properly.