### PR TITLE
cabal2nix: support Cabal >= 3.18

### DIFF
--- a/cabal2nix/CHANGELOG.md
+++ b/cabal2nix/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision History for cabal2nix
 
+## TBD
+
+* Support building against Cabal `>= 3.18`, see
+  [#721](https://github.com/NixOS/cabal2nix/pull/721).
+
 ## 2.21.3
 
 * Add `--src-expression` flag to `cabal2nix` which allows overriding

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/OrphanInstances.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 
 module Distribution.Nixpkgs.Haskell.OrphanInstances ( ) where
 
@@ -20,7 +21,9 @@ import Distribution.Version
 import Language.Nix.PrettyPrinting as Nix
 
 instance NFData CompilerInfo
+#if !MIN_VERSION_Cabal(3,18,0)
 instance NFData AbiTag
+#endif
 
 instance IsString Version where
   fromString = text2isString "Version"

--- a/cabal2nix/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
+++ b/cabal2nix/src/Distribution/Nixpkgs/Haskell/PackageSourceSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE CPP #-}
 module Distribution.Nixpkgs.Haskell.PackageSourceSpec
   ( HpackUse(..), Package(..), getPackage, getPackage', loadHackageDB, sourceFromHackage
   ) where
@@ -307,10 +308,15 @@ runParseGenericPackageDescription
   -> BS.ByteString
   -> Either String Cabal.GenericPackageDescription
 runParseGenericPackageDescription fpath
-  = first (unlines . map (showPError fpath) . toList . snd)
+  = first (unlines . map showPErrorCompat . toList . snd)
   . snd . runParseResult
   . parseGenericPackageDescription
-
+  where
+#if MIN_VERSION_Cabal(3,18,0)
+    showPErrorCompat = showPErrorWithSource
+#else
+    showPErrorCompat = showPError fpath
+#endif
 setCabalFileHash :: String -> GenericPackageDescription -> GenericPackageDescription
 setCabalFileHash sha256 gpd = gpd { packageDescription = (packageDescription gpd) {
                                       customFieldsPD = ("X-Cabal-File-Hash", sha256) : customFieldsPD (packageDescription gpd)

--- a/cabal2nix/test/Main.hs
+++ b/cabal2nix/test/Main.hs
@@ -80,11 +80,18 @@ testLibrary cabalFile = do
     goldenFile
     nixFile
 #if MIN_VERSION_Cabal(3,14,0)
-    (readGenericPackageDescription silent Nothing (makeSymbolicPath cabalFile)
+    (readGenericPackageDescription silentCompat Nothing (makeSymbolicPath cabalFile)
 #else
-    (readGenericPackageDescription silent cabalFile
+    (readGenericPackageDescription silentCompat cabalFile
 #endif
      >>= writeFileLn nixFile . prettyShow . cabal2nix)
+
+silentCompat :: Verbosity
+#if MIN_VERSION_Cabal(3,18,0)
+silentCompat = mkVerbosity defaultVerbosityHandles silent
+#else
+silentCompat = silent
+#endif
 
 -- | TODO:
 --


### PR DESCRIPTION
Needs `--allow-newer Cabal-syntax` to test with hpack.